### PR TITLE
Codebility | CODEB-34: Styling Sidebar Layout Issue

### DIFF
--- a/apps/codebility/hooks/use-sidebar.ts
+++ b/apps/codebility/hooks/use-sidebar.ts
@@ -7,7 +7,7 @@ interface PostStore {
 }
 
 export const useNavStore = create<PostStore>((set) => ({
-  isToggleOpen: false,
+  isToggleOpen: true,
   toggleNav: () => set((state) => ({ isToggleOpen: !state.isToggleOpen })),
   closeNav: () => set((state) => ({ isToggleOpen: false })),
 }));


### PR DESCRIPTION
User Story:
As a user, I want the sidebar layout to be displayed by default and not collapsed so that I can easily access navigation options without having to manually expand the sidebar.

Acceptance Criteria:

- [x]  The sidebar layout should be displayed on the page by default when the user logs in.
- [x] The sidebar should contain all necessary navigation options for the user to easily navigate the application.

![image](https://github.com/user-attachments/assets/bcde7313-d6d9-44ee-9da6-84ac7bfe0bb1)