### PR TITLE
Adrian/settings resume fix my time schedule

### DIFF
--- a/apps/codebility/Components/time-picker/period-select.tsx
+++ b/apps/codebility/Components/time-picker/period-select.tsx
@@ -1,63 +1,86 @@
-"use client"
+"use client";
 
-import * as React from "react"
-
-import { Period, display12HourValue, setDateByType } from "@/Components/time-picker/time-picker-utils"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/Components/ui/select"
+import * as React from "react";
+import {
+  display12HourValue,
+  Period,
+  setDateByType,
+} from "@/Components/time-picker/time-picker-utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/Components/ui/select";
 
 export interface PeriodSelectorProps {
-  period: Period
+  period: Period;
   // eslint-disable-next-line no-unused-vars
-  setPeriod: (m: Period) => void
-  date: Date | undefined
+  setPeriod: (m: Period) => void;
+  date: Date | undefined;
   // eslint-disable-next-line no-unused-vars
-  setDate: (date: Date | undefined) => void
-  onRightFocus?: () => void
-  onLeftFocus?: () => void
-  disabled?: boolean
+  setDate: (date: Date | undefined) => void;
+  onRightFocus?: () => void;
+  onLeftFocus?: () => void;
+  disabled?: boolean;
 }
 
-export const TimePeriodSelect = React.forwardRef<HTMLButtonElement, PeriodSelectorProps>(
-  ({ period, setPeriod, date, setDate, onLeftFocus, onRightFocus, disabled }, ref) => {
+export const TimePeriodSelect = React.forwardRef<
+  HTMLButtonElement,
+  PeriodSelectorProps
+>(
+  (
+    { period, setPeriod, date, setDate, onLeftFocus, onRightFocus, disabled },
+    ref,
+  ) => {
     const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (e.key === "ArrowRight") onRightFocus?.()
-      if (e.key === "ArrowLeft") onLeftFocus?.()
-    }
+      if (e.key === "ArrowRight") onRightFocus?.();
+      if (e.key === "ArrowLeft") onLeftFocus?.();
+    };
 
     const handleValueChange = (value: Period) => {
-      setPeriod(value)
+      setPeriod(value);
 
       /**
        * trigger an update whenever the user switches between AM and PM;
        * otherwise user must manually change the hour each time
        */
       if (date) {
-        const tempDate = new Date(date)
-        const hours = display12HourValue(date.getHours())
-        const newDate = setDateByType(tempDate, hours.toString(), "12hours", value);
+        const tempDate = new Date(date);
+        const hours = display12HourValue(date.getHours());
+        const newDate = setDateByType(
+          tempDate,
+          hours.toString(),
+          "12hours",
+          value,
+        );
 
         setDate(newDate);
       }
-    }
+    };
 
     return (
-      <div className="flex h-10 items-center">
-        <Select disabled={disabled} defaultValue={period} onValueChange={(value: Period) => handleValueChange(value)}>
-          <SelectTrigger
-            ref={ref}
-            className="background-box w-[65px] focus:bg-accent focus:text-accent-foreground"
-            onKeyDown={handleKeyDown}
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="AM">AM</SelectItem>
-            <SelectItem value="PM">PM</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-    )
-  }
-)
+      <Select
+        disabled={disabled}
+        defaultValue={period}
+        onValueChange={(value: Period) => handleValueChange(value)}
+      >
+        <SelectTrigger
+          ref={ref}
+          className="background-box w-[48px] rounded-sm border-none p-3 text-center text-sm focus:bg-accent focus:text-accent-foreground lg:py-2"
+          onKeyDown={handleKeyDown}
+          isArrow={false}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="AM">AM</SelectItem>
+          <SelectItem value="PM">PM</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+  },
+);
 
-TimePeriodSelect.displayName = "TimePeriodSelect"
+TimePeriodSelect.displayName = "TimePeriodSelect";

--- a/apps/codebility/Components/time-picker/time-picker-12hour-demo.tsx
+++ b/apps/codebility/Components/time-picker/time-picker-12hour-demo.tsx
@@ -7,28 +7,32 @@ import { Period } from "@/Components/time-picker/time-picker-utils";
 
 import { Label } from "@codevs/ui/label";
 
-
 interface TimePickerProps {
-  date?: Date
-  period: Period
+  date?: Date;
+  period: Period;
   // eslint-disable-next-line no-unused-vars
-  setDate: (date: Date | undefined) => void
-  disabled?: boolean
+  setDate: (date: Date | undefined) => void;
+  disabled?: boolean;
 }
 
-export function TimePicker12({ date, setDate, period, disabled = false }: TimePickerProps) {
-  const [currentPeriod, setCurrentPeriod] = React.useState<Period>(period)
+export function TimePicker12({
+  date,
+  setDate,
+  period,
+  disabled = false,
+}: TimePickerProps) {
+  const [currentPeriod, setCurrentPeriod] = React.useState<Period>(period);
 
-  const minuteRef = React.useRef<HTMLInputElement>(null)
-  const hourRef = React.useRef<HTMLInputElement>(null)
- 
-  const periodRef = React.useRef<HTMLButtonElement>(null)
+  const minuteRef = React.useRef<HTMLInputElement>(null);
+  const hourRef = React.useRef<HTMLInputElement>(null);
+
+  const periodRef = React.useRef<HTMLButtonElement>(null);
   const handleDateChange = (newDate: Date | undefined) => {
-    setDate(newDate)
-  }
+    setDate(newDate);
+  };
   return (
-    <div className="flex items-end gap-2">
-      <div className="grid gap-1 text-center">
+    <div className="grid grid-cols-3 gap-2">
+      <div className="min:w-[48px] flex h-full flex-col justify-between text-center">
         <Label htmlFor="hours" className="text-xs">
           Hours
         </Label>
@@ -42,7 +46,7 @@ export function TimePicker12({ date, setDate, period, disabled = false }: TimePi
           onRightFocus={() => minuteRef.current?.focus()}
         />
       </div>
-      <div className="grid gap-1 text-center">
+      <div className="min:w-[48px] flex h-full flex-col justify-between text-center">
         <Label htmlFor="minutes" className="text-xs">
           Minutes
         </Label>
@@ -55,17 +59,16 @@ export function TimePicker12({ date, setDate, period, disabled = false }: TimePi
           disabled={disabled}
           onLeftFocus={() => hourRef.current?.focus()}
           onRightFocus={() => periodRef.current?.focus()}
-        
         />
       </div>
-    
-      <div className="grid gap-1 text-center">
+
+      <div className="min:w-[48px] flex h-full flex-col justify-between text-center">
         <Label htmlFor="period" className="text-xs">
           Period
         </Label>
         <TimePeriodSelect
-         period={currentPeriod}
-         setPeriod={setCurrentPeriod}
+          period={currentPeriod}
+          setPeriod={setCurrentPeriod}
           date={date}
           setDate={handleDateChange}
           ref={periodRef}

--- a/apps/codebility/Components/ui/select.tsx
+++ b/apps/codebility/Components/ui/select.tsx
@@ -15,8 +15,10 @@ const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    isArrow?: boolean;
+  }
+>(({ className, children, isArrow = true, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
@@ -26,9 +28,11 @@ const SelectTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild>
-      <IconDropdown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
+    {isArrow && (
+      <SelectPrimitive.Icon asChild>
+        <IconDropdown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    )}
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;

--- a/apps/codebility/app/home/settings/resume/_components/resume-time-schedule.tsx
+++ b/apps/codebility/app/home/settings/resume/_components/resume-time-schedule.tsx
@@ -29,9 +29,7 @@ const TimeSchedule = ({ data }: TimeScheduleProps) => {
     const { date } = parseTime(data?.end_time || "");
     setEnd(date.toTimeString().substring(0, 5));
   }, [data?.end_time]);
-  const handleEditClick = () => {
-    setIsEditMode(!isEditMode);
-  };
+
   const handleSaveClick = async () => {
     setIsLoading(true);
     const toastId = toast.loading("Your time schedule was being updated");
@@ -63,8 +61,12 @@ const TimeSchedule = ({ data }: TimeScheduleProps) => {
   return (
     <Box className="bg-light-900 dark:bg-dark-100 relative flex flex-col gap-2">
       <IconEdit
-        className="w-15 h-15 absolute right-6 top-6 cursor-pointer invert dark:invert-0"
-        onClick={handleEditClick}
+        className={` ${
+          isEditMode
+            ? "hidden"
+            : "w-15 h-15 absolute right-6 top-6 cursor-pointer invert dark:invert-0"
+        }  `}
+        onClick={() => setIsEditMode(true)}
       />
       <p className="text-lg">My Time Schedule</p>
       <Paragraph className="py-4">
@@ -100,7 +102,7 @@ const TimeSchedule = ({ data }: TimeScheduleProps) => {
         <div className="mt-4 flex justify-end gap-2">
           <Button
             variant="hollow"
-            onClick={handleSaveClick}
+            onClick={() => setIsEditMode(false)}
             disabled={isLoading}
           >
             Cancel

--- a/apps/codebility/app/home/settings/resume/_components/resume-time-schedule.tsx
+++ b/apps/codebility/app/home/settings/resume/_components/resume-time-schedule.tsx
@@ -71,7 +71,7 @@ const TimeSchedule = ({ data }: TimeScheduleProps) => {
         Update your time schedule here. This will help us to monitor your
         working hours.
       </Paragraph>
-      <div className="flex flex-col gap-6 sm:flex-row md:flex-col xl:flex-row">
+      <div className="flex flex-col gap-6 sm:flex-row md:flex-col 2xl:flex-row">
         <div className="flex flex-1 flex-col items-center gap-4 rounded-lg border border-zinc-700 p-6">
           <p className="text-lg">Start Time</p>
 

--- a/apps/codebility/app/home/settings/resume/page.tsx
+++ b/apps/codebility/app/home/settings/resume/page.tsx
@@ -50,14 +50,14 @@ const Resume = async () => {
           "Something went wrong!"
         ) : (
           <div className="flex flex-col gap-8 md:flex-row">
-            <div className="flex w-full basis-[70%] flex-col gap-8">
+            <div className="flex w-full basis-[70%] flex-col gap-8 2xl:basis-[60%]">
               <PersonalInfo data={profileData as Profile_Types} />
               <About data={profileData as Profile_Types} />
               <ContactInfo data={socialData as Social_Types} />
               <Experience data={experienceData as Experience_Type[]} />
               <Skills data={profileData as Profile_Types} />
             </div>
-            <div className="flex w-full basis-[30%] flex-col gap-8">
+            <div className="flex w-full basis-[30%] flex-col gap-8 2xl:basis-[40%]">
               <Photo data={profileData as Profile_Types} />
               <TimeSchedule data={profileData as Profile_Types} />
             </div>


### PR DESCRIPTION
- fixed alignment of the three fields: hour input, minute input, and period input.
- edit mode button hides when edit mode is set to true. (same behavior with other fields)
- adjusted flex basis of the page to accommodate start time and end time layout.
- added isArrow props on top of the default ShadCN's `<SelectTrigger>` element to remove the default arrow.

![image](https://github.com/user-attachments/assets/95fdb9e4-34a3-4779-bad4-ec4e725ec421)
![image](https://github.com/user-attachments/assets/2a694715-601e-4bec-a087-b5a6125d9eb0)
