### PR TITLE
Rowell/fix  applicants extra html element rendering

### DIFF
--- a/apps/codebility/app/home/applicants/_components/ApplicantsTableDesktop.tsx
+++ b/apps/codebility/app/home/applicants/_components/ApplicantsTableDesktop.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import ApplicantsActionButtons from "@/app/home/applicants/_components/ApplicantsActionButtons";
 import DefaultAvatar from "@/Components/DefaultAvatar";
 import {
   Table,

--- a/apps/codebility/app/home/applicants/_components/ApplicantsTableDesktop.tsx
+++ b/apps/codebility/app/home/applicants/_components/ApplicantsTableDesktop.tsx
@@ -20,8 +20,6 @@ import {
   HoverCardTrigger,
 } from "@codevs/ui/hover-card";
 
-import ApplicantsApprovalButtons from "./ApplicantsActionButtons";
-
 const ApplicantsTableDesktop = ({ applicants }: { applicants: Codev[] }) => {
   return (
     <Table className="hidden xl:block">
@@ -150,7 +148,7 @@ const ApplicantsTableDesktop = ({ applicants }: { applicants: Codev[] }) => {
                 </div>
               </TableCell>
               <TableCell className="py-4 text-center">
-                <ApplicantsApprovalButtons applicant={applicant} />
+                <ApplicantsActionButtons applicant={applicant} />
               </TableCell>
             </TableRow>
           ))

--- a/apps/codebility/app/home/applicants/_components/ApplicantsTableMobile.tsx
+++ b/apps/codebility/app/home/applicants/_components/ApplicantsTableMobile.tsx
@@ -21,11 +21,9 @@ import {
 import { Avatar, AvatarImage } from "@codevs/ui/avatar";
 
 const ApplicantsTableMobile = ({ applicants }: { applicants: Codev[] }) => {
-  const applicantsLen = applicants?.length || 0;
-
   return (
     <div className="block xl:hidden">
-      {applicantsLen > 0 &&
+      {applicants.length > 0 &&
         applicants.map((applicant) => (
           <Accordion
             key={applicant.id}
@@ -46,12 +44,9 @@ const ApplicantsTableMobile = ({ applicants }: { applicants: Codev[] }) => {
                       <DefaultAvatar size={40} />
                     )}
                   </Avatar>
-                  <p className="border-2 text-sm capitalize">
+                  <p className="text-sm capitalize">
                     {applicant.first_name} {applicant.last_name}
                   </p>
-                </div>
-                <div className="hidden w-1/2 justify-end pr-4 md:flex md:pr-8">
-                  <ApplicantsActionButtons applicant={applicant} />
                 </div>
               </AccordionTrigger>
               <AccordionContent className="p-4">
@@ -92,18 +87,17 @@ const ApplicantsTableMobile = ({ applicants }: { applicants: Codev[] }) => {
                       <TableCell className="text-sm">Tech Stack</TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-2">
-                          {applicant.tech_stacks &&
-                            applicant.tech_stacks.map((stack, i) => (
-                              <Image
-                                key={i}
-                                src={`/assets/svgs/icon-${stack.toLowerCase()}.svg`}
-                                alt={`${stack} icon`}
-                                width={25}
-                                height={25}
-                                title={stack}
-                                className="h-[25px] w-[25px] transition duration-300 hover:-translate-y-0.5"
-                              />
-                            ))}
+                          {applicant.tech_stacks.map((stack, i) => (
+                            <Image
+                              key={i}
+                              src={`/assets/svgs/icon-${stack.toLowerCase()}.svg`}
+                              alt={`${stack} icon`}
+                              width={25}
+                              height={25}
+                              title={stack}
+                              className="h-[25px] w-[25px] transition duration-300 hover:-translate-y-0.5"
+                            />
+                          ))}
                         </div>
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/2c758aba-a538-433d-8e97-66d2e64e2c97)

After
![image](https://github.com/user-attachments/assets/6ca9f19a-eed3-4002-8216-50f5c45a0c11)
![image](https://github.com/user-attachments/assets/775c65a0-1628-4695-8853-38e73bba53f1)

Cause of extra element rendering is the duplicate implementation of <ApplicantsActionButtons applicant={applicant} /> in ApplicantsTableMobile component

