### PR TITLE
miguel/ fix delete image

### DIFF
--- a/apps/codebility/utils/uploadImage.ts
+++ b/apps/codebility/utils/uploadImage.ts
@@ -87,7 +87,7 @@ export async function getImagePath(url: string): Promise<string | null> {
     const urlObj = new URL(url);
     const pathParts = urlObj.pathname.split("/");
     // Remove the bucket name and 'object' from the path
-    return pathParts.slice(2).join("/");
+    return pathParts.slice(6).join("/");
   } catch {
     return null;
   }


### PR DESCRIPTION
Issue: images in buckets are not properly deleted
Cause: Wrong slicing in getImagePath

Before:
![image](https://github.com/user-attachments/assets/088dd321-dda5-4bfe-a9e4-ba819216e027)

After:
![image](https://github.com/user-attachments/assets/d7c2d2a1-0a79-4153-911a-1bef22b0f4ef)
