### PR TITLE
Add fallback handling for broken project icons in Current Projects section

### DIFF
--- a/apps/codebility/app/home/(dashboard)/_components/DashboardCurrentProject.tsx
+++ b/apps/codebility/app/home/(dashboard)/_components/DashboardCurrentProject.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { Box } from "@/components/shared/dashboard";
-import { Skeleton } from "@/components/ui/skeleton/skeleton";
+import { Box } from "@/Components/shared/dashboard";
+import { Skeleton } from "@/Components/ui/skeleton/skeleton";
 import { useUserStore } from "@/store/codev-store";
 import { createClientClientComponent } from "@/utils/supabase/client";
 
@@ -26,6 +26,8 @@ const DashboardCurrentProject = () => {
   const [projects, setProjects] = useState<ProjectInvolvement[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [supabase, setSupabase] = useState<any>(null);
+  // Track image load errors for each project
+  const [imageErrors, setImageErrors] = useState<Record<string, boolean>>({});
 
   // Initialize Supabase client safely
   useEffect(() => {
@@ -87,6 +89,31 @@ const DashboardCurrentProject = () => {
     fetchProjects();
   }, [user, supabase]);
 
+  // Handle image load errors
+  const handleImageError = (projectId: string) => {
+    setImageErrors(prev => ({
+      ...prev,
+      [projectId]: true
+    }));
+  };
+
+  // Get project image source with fallback logic
+  const getProjectImageSrc = (project: ProjectInvolvement['project']) => {
+    // If we know this image has failed to load, use fallback immediately
+    if (imageErrors[project.id]) {
+      return "https://codebility-cdn.pages.dev/assets/images/default-avatar-200x200.jpg";
+    }
+    
+    // If main_image is null or empty, use fallback
+    if (!project.main_image || project.main_image.trim() === "") {
+      return "https://codebility-cdn.pages.dev/assets/images/default-avatar-200x200.jpg";
+    }
+    
+    // Return the original image
+    return project.main_image;
+  };
+
+  // Loading state
   if (isLoading) {
     return (
       <Box className="flex w-full flex-1 flex-col gap-4">
@@ -99,12 +126,13 @@ const DashboardCurrentProject = () => {
     );
   }
 
+  // Status styling function
   function getStatusClass(status: string | undefined) {
     switch (status) {
       case "pending":
         return "text-white bg-orange-500/80";
       case "completed":
-        return "text-white bg-customBlue-500/80";
+        return "text-white bg-blue-500/80";
       case "active":
         return "text-white bg-green-500/80";
       default:
@@ -122,25 +150,24 @@ const DashboardCurrentProject = () => {
               key={involvement.project.id}
               projectId={involvement.project.id}
             >
-              <div className="p-[1px]-100 rounded-md bg-gradient-to-r from-purple-200 via-customBlue-50 to-sky-300 dark:from-purple-800 dark:via-customBlue-300 dark:to-sky-950  p-2 hover:shadow-lg hover:shadow-customBlue-500/50 dark:hover:shadow-customBlue-400/50">
+              <div className="p-[1px] rounded-md bg-gradient-to-r from-purple-200 via-blue-50 to-sky-300 dark:from-purple-800 dark:via-blue-300 dark:to-sky-950 p-2 hover:shadow-lg hover:shadow-blue-500/50 dark:hover:shadow-blue-400/50">
                 <div className="flex items-center gap-2">
-                  {involvement.project.main_image && (
-                    <div className="h-8 w-8 overflow-hidden rounded bg-gray-100 dark:bg-gray-800">
-                      <Image
-                        src={involvement.project.main_image}
-                        alt={involvement.project.name}
-                        width={32}
-                        height={32}
-                        className="h-full w-full object-cover"
-                        style={{
-                          width: '32px',
-                          height: '32px',
-                        }}
-                      />
-                    </div>
-                  )}
+                  {/* Enhanced image handling with fallback */}
+                  <div className="relative h-8 w-8 flex-shrink-0">
+                    <Image
+                      src={getProjectImageSrc(involvement.project)}
+                      alt={`${involvement.project.name} project icon`}
+                      width={32}
+                      height={32}
+                      className="rounded object-cover"
+                      onError={() => handleImageError(involvement.project.id)}
+                      // Add unoptimized for external URLs
+                      unoptimized={getProjectImageSrc(involvement.project).includes('http')}
+                    />
+                  </div>
+
                   <div className="flex min-w-0 flex-1 items-center justify-between">
-                    <div className="flex min-w-0 flex-col ">
+                    <div className="flex min-w-0 flex-col">
                       <p className="truncate text-sm font-medium">
                         {involvement.project.name}
                       </p>
@@ -152,7 +179,7 @@ const DashboardCurrentProject = () => {
                     </div>
                     <Badge
                       variant="outline"
-                      className={`ml-2 shrink-0 whitespace-nowrap text-xs  ${getStatusClass(involvement.project.status)}`}
+                      className={`ml-2 shrink-0 whitespace-nowrap text-xs ${getStatusClass(involvement.project.status)}`}
                     >
                       {involvement.project.status === "inprogress"
                         ? "In Progress"

--- a/apps/codebility/app/home/(dashboard)/_components/DashboardCurrentProject.tsx
+++ b/apps/codebility/app/home/(dashboard)/_components/DashboardCurrentProject.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { Box } from "@/Components/shared/dashboard";
-import { Skeleton } from "@/Components/ui/skeleton/skeleton";
+import { Box } from "@/components/shared/dashboard";
+import { Skeleton } from "@/components/ui/skeleton/skeleton";
 import { useUserStore } from "@/store/codev-store";
 import { createClientClientComponent } from "@/utils/supabase/client";
 


### PR DESCRIPTION
 Implements smart fallback to default avatar when images are null/invalid
<img width="738" height="169" alt="Screenshot 2025-08-03 at 8 32 14 PM" src="https://github.com/user-attachments/assets/3266bfe6-bc17-4358-b817-ea8645bd79e2" />


**After:**
<img width="737" height="149" alt="Screenshot 2025-08-03 at 9 33 19 PM" src="https://github.com/user-attachments/assets/349da20c-1eaf-4f3b-a2d0-e7497eb1b058" />
