### PR TITLE
Remove Status Switch Button and Label from DashboardProfile Component

### DIFF
--- a/apps/codebility/app/home/(dashboard)/_components/DashboardProfile.tsx
+++ b/apps/codebility/app/home/(dashboard)/_components/DashboardProfile.tsx
@@ -155,7 +155,7 @@ export default function DashboardProfile() {
                   </div>
                 </Badge>
 
-                <SwitchStatusButton
+                {/* <SwitchStatusButton
                   isActive={active}
                   disabled={activeloading}
                   handleSwitch={handleStatusSwitch}
@@ -163,7 +163,7 @@ export default function DashboardProfile() {
 
                 <p className="hidden max-w-[80px] text-center text-[10px] leading-tight text-gray-500 dark:text-gray-400 sm:block sm:text-xs">
                   {active ? "Available for work" : "Away"}
-                </p>
+                </p> */}
               </div>
             )}
           </div>


### PR DESCRIPTION
Commented out lines 158-166 in the DashboardProfile component to disable the SwitchStatusButton and its associated label (`<p>` element). This removes the ability to toggle the user availability status and display the "Available for work" or "Away" text from the UI.

<img width="558" height="175" alt="Screenshot 2025-10-03 at 2 15 29 AM" src="https://github.com/user-attachments/assets/f6415b34-4fe8-4ada-bbb8-a198248225be" />
