### PR TITLE
fix(AdminDashboard): remove unintended gray background

### DIFF
--- a/apps/codebility/app/home/admin-dashboard/layout.tsx
+++ b/apps/codebility/app/home/admin-dashboard/layout.tsx
@@ -6,7 +6,7 @@ export default function AdminDashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen ">
       {/* Background decorations */}
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute -left-4 -top-4 h-72 w-72 rounded-full bg-gradient-to-br from-blue-400/10 to-purple-400/10 blur-3xl" />


### PR DESCRIPTION
🎫 Ticket Title

Clarification: Remove grayish background from /home/admin-dashboard

📝 Description

The Admin Dashboard (/home/admin-dashboard) currently displays a grayish background. The task was to confirm whether this background should be removed for a cleaner, consistent layout.

Resolution:
Grayish background successfully removed as per clarification. The dashboard now displays the intended clean background.

! [See snippet for confirmation.]
(<img width="1881" height="975" alt="Screenshot 2025-10-22 211845" src="https://github.com/user-attachments/assets/91ab0b29-a4a9-4248-9fbf-0bf9b1a1113d" />)
