### PR TITLE
✅ Fixed Settings Page & Restrict visibility of team management buttons (Manage Members, Schedule Meeting) to team leads only

### DIFF
--- a/apps/codebility/app/home/my-team/[projectId]/_components/TeamDetailView.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/_components/TeamDetailView.tsx
@@ -28,12 +28,12 @@ import { getMeetingSchedule, getTeamMonthlyAttendancePoints } from "../actions";
  * ✅ Team View tab: Always visible to everyone
  * ✅ Attendance tab: Only visible to team leads
  * ✅ Checklist button: Only visible to team leads
- * ✅ Schedule Meeting button: Always visible
- * ✅ Manage Members button: Always visible (in Team View)
+ * ✅ Schedule Meeting button: Only visible to team leads
+ * ✅ Manage Members button: Only visible to team leads (in Team View)
  * 
  * BEHAVIOR:
- * - Regular members: See only Team View tab
- * - Team leads: See Team View + Attendance tabs + Checklist button
+ * - Regular members: See only Team View tab (read-only)
+ * - Team leads: Full control over all team management features
  */
 
 interface ProjectData {
@@ -342,8 +342,8 @@ const TeamDetailView = ({ projectData }: TeamDetailViewProps) => {
               </>
             )}
             
-            {/* Manage Members - Only in team view */}
-            {viewMode === "team" && (
+            {/* Manage Members - ONLY VISIBLE TO TEAM LEADS in Team View */}
+            {viewMode === "team" && isCurrentUserTeamLead && (
               <Button
                 onClick={handleOpenAddModal}
                 disabled={isLoadingMembers}
@@ -355,17 +355,19 @@ const TeamDetailView = ({ projectData }: TeamDetailViewProps) => {
               </Button>
             )}
             
-            {/* Schedule Meeting - Always visible */}
-            <Button
-              variant="outline"
-              size="sm"
-              className="flex items-center gap-1.5 text-xs px-3 py-1.5 h-auto border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-              title="Schedule Meetings"
-              onClick={() => setShowScheduleMeetingModal(true)}
-            >
-              <CalendarDays className="h-3.5 w-3.5" />
-              Schedule Meeting
-            </Button>
+            {/* Schedule Meeting - ONLY VISIBLE TO TEAM LEADS */}
+            {isCurrentUserTeamLead && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex items-center gap-1.5 text-xs px-3 py-1.5 h-auto border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                title="Schedule Meetings"
+                onClick={() => setShowScheduleMeetingModal(true)}
+              >
+                <CalendarDays className="h-3.5 w-3.5" />
+                Schedule Meeting
+              </Button>
+            )}
           </div>
         </div>
 

--- a/apps/codebility/app/home/settings/page.tsx
+++ b/apps/codebility/app/home/settings/page.tsx
@@ -28,7 +28,8 @@ type RolePermissions = {
 
 type PermissionKey = keyof RolePermissions;
 
-// Admin-only cards that require role_id = 1
+// Admin-only cards - only visible to Admin role (role_id = 1)
+// Hidden from: Codev (10), Intern (4), HR (2), and all other non-admin roles
 const ADMIN_ONLY_PATHS = [
   "/home/settings/news-banners",
   "/home/settings/services",
@@ -59,31 +60,36 @@ const Settings = () => {
 
     async function fetchUserRole() {
       try {
+        console.log('[AUTH] Fetching user session...');
+        
         // Get auth user
         const { data: { session }, error: sessionError } = await supabase.auth.getSession();
         
         if (sessionError || !session?.user?.email) {
-          console.error("Failed to get session:", sessionError);
+          console.error("[AUTH] Failed to get session:", sessionError);
           setLoading(false);
           return;
         }
+
+        console.log(`[AUTH] ✅ Logged in as: ${session.user.email}`);
 
         // Map email to codev profile to get role_id
         const { data: codevData, error: codevError } = await supabase
           .from("codev")
-          .select("role_id")
+          .select("role_id, first_name, last_name")
           .eq("email_address", session.user.email)
           .single();
 
         if (codevError || !codevData) {
-          console.error("Failed to fetch user role:", codevError);
+          console.error("[AUTH] Failed to fetch user role:", codevError);
           setLoading(false);
           return;
         }
 
+        console.log(`[AUTH] ✅ User: ${codevData.first_name} ${codevData.last_name}, role_id: ${codevData.role_id}`);
         setRoleId(codevData.role_id);
       } catch (err) {
-        console.error("Error fetching user role:", err);
+        console.error("[AUTH] Error fetching user role:", err);
         setLoading(false);
       }
     }
@@ -97,23 +103,26 @@ const Settings = () => {
 
     async function fetchRolePermissions() {
       try {
+        console.log(`[PERMISSIONS] Fetching permissions for role_id: ${roleId}`);
+        
         const { data: roleData, error: roleError } = await supabase
           .from("roles")
           .select(
-            "dashboard, kanban, time_tracker, interns, applicants, inhouse, clients, projects, settings, orgchart, resume, permissions, roles"
+            "id, name, dashboard, kanban, time_tracker, interns, applicants, inhouse, clients, projects, settings, orgchart, resume, permissions, roles"
           )
           .eq("id", roleId)
           .single();
 
         if (roleError || !roleData) {
-          console.error("Failed to fetch role permissions:", roleError);
+          console.error("[PERMISSIONS] Failed to fetch role permissions:", roleError);
           setLoading(false);
           return;
         }
 
+        console.log(`[PERMISSIONS] ✅ Role: ${roleData.name}`, roleData);
         setRolePermissions(roleData);
       } catch (err) {
-        console.error("Error fetching role permissions:", err);
+        console.error("[PERMISSIONS] Error fetching role permissions:", err);
       } finally {
         setLoading(false);
       }
@@ -146,8 +155,10 @@ const Settings = () => {
   // Filter settings cards based on role
   const filteredCards = settingsCardData.filter((card) => {
     // Rule 1: Admin-only cards (News Banners, Services)
-    // Only visible if user has role_id = 1 (Admin)
+    // ONLY visible if user has role_id = 1 (Admin)
+    // BLOCKED for: Codev (10), Intern (4), HR (2), all others
     if (ADMIN_ONLY_PATHS.includes(card.path)) {
+      console.log(`[FILTER] Checking admin-only card: ${card.path}, roleId: ${roleId}, isAdmin: ${roleId === 1}`);
       return roleId === 1;
     }
 
@@ -155,12 +166,18 @@ const Settings = () => {
     // For cards like Profile, Permissions, Roles
     const permissionKey = settingsPermissionMap[card.path];
     if (permissionKey) {
-      return hasPermission(permissionKey);
+      const hasAccess = hasPermission(permissionKey);
+      console.log(`[FILTER] Checking ${card.path}, permission: ${permissionKey}, hasAccess: ${hasAccess}`);
+      return hasAccess;
     }
 
     // Rule 3: Default fallback - require general "settings" permission
-    return hasPermission("settings");
+    const hasAccess = hasPermission("settings");
+    console.log(`[FILTER] Checking ${card.path} (default), hasAccess: ${hasAccess}`);
+    return hasAccess;
   });
+
+  console.log(`[FILTER] Total cards: ${settingsCardData.length}, Filtered: ${filteredCards.length}, RoleId: ${roleId}`);
 
   return (
     <PageContainer maxWidth="xl">


### PR DESCRIPTION
<img width="1272" height="524" alt="Screenshot 2025-11-07 at 2 34 23 AM" src="https://github.com/user-attachments/assets/c6a75b1f-d710-4388-91e2-3ec78a5a579b" />
****Testing Steps**:**

Log in as Raineer (role_id = 4)

Go to /home/settings
Should see ONLY "Account Settings" card
News Banners and Services should be hidden

Log in as Admin (role_id = 1)

Go to /home/settings
Should see ALL cards (News Banners, Services, Account Settings, etc.)

<img width="459" height="94" alt="Screenshot 2025-11-07 at 2 36 25 AM" src="https://github.com/user-attachments/assets/01015703-2043-48e3-8eaf-0876b1e2063a" />
<img width="415" height="66" alt="Screenshot 2025-11-07 at 3 04 14 AM" src="https://github.com/user-attachments/assets/e64a4dc0-70dc-4266-aff2-273f2deeca11" />


Final Verification
As Raineer (Codev): Should see ONLY Account Settings
As Admin: Should see ALL 3 cards

[ my team page ]
**Restrict visibility of team management buttons (Manage Members, Schedule Meeting) to team leads only**

