### PR TITLE
Add Facebook link to applicants management Links column

### DIFF
--- a/apps/codebility/app/home/applicants/_components/_table/applicantColumns.tsx
+++ b/apps/codebility/app/home/applicants/_components/_table/applicantColumns.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { IconGithub, IconLink } from "@/public/assets/svgs";
+import { IconFacebook, IconGithub, IconLink } from "@/public/assets/svgs";
 import { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
 
@@ -142,6 +142,18 @@ export const applicantsColumns: ColumnDef<NewApplicantType>[] = [
           ) : (
             <div className="w-7 h-7"></div>
           )}
+          {applicant.facebook ? (
+            <Link
+              href={applicant.facebook}
+              target="_blank"
+              className="rounded-full p-1.5 text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              title="Facebook"
+            >
+              <IconFacebook className="h-4 w-4 invert dark:invert-0" />
+            </Link>
+          ) : (
+            <div className="w-7 h-7"></div>
+          )}
           {applicant.portfolio_website ? (
             <Link
               href={applicant.portfolio_website}
@@ -154,7 +166,7 @@ export const applicantsColumns: ColumnDef<NewApplicantType>[] = [
           ) : (
             <div className="w-7 h-7"></div>
           )}
-          {!applicant.github && !applicant.portfolio_website && (
+          {!applicant.github && !applicant.facebook && !applicant.portfolio_website && (
             <span className="text-sm text-gray-500 dark:text-gray-500">
               None
             </span>

--- a/apps/codebility/app/home/applicants/_components/_table/applicantProfileColSec.tsx
+++ b/apps/codebility/app/home/applicants/_components/_table/applicantProfileColSec.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import DefaultAvatar from "@/components/DefaultAvatar";
 import { Button } from "@/components/ui/button";
 import { Table, TableCell, TableHeader, TableRow } from "@/components/ui/table";
-import { IconEmail, IconGithub, IconLink } from "@/public/assets/svgs";
+import { IconEmail, IconFacebook, IconGithub, IconLink } from "@/public/assets/svgs";
 import { Row } from "@tanstack/react-table";
 
 import {
@@ -153,6 +153,22 @@ export default function ApplicantProfileColSec({
                     {applicant.github ? (
                       <Link href={applicant.github} target="_blank">
                         <IconGithub className="h-5 w-5 invert dark:invert-0" />
+                      </Link>
+                    ) : (
+                      <span className="text-sm text-gray-500 dark:text-gray-500">
+                        None
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Facebook Row */}
+                <div className="flex items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Facebook</span>
+                  <div>
+                    {applicant.facebook ? (
+                      <Link href={applicant.facebook} target="_blank">
+                        <IconFacebook className="h-5 w-5 invert dark:invert-0" />
                       </Link>
                     ) : (
                       <span className="text-sm text-gray-500 dark:text-gray-500">


### PR DESCRIPTION
Added Facebook icon and link display in both desktop and mobile views of the applicants table. The Facebook link appears between GitHub and Portfolio links, maintaining consistent styling and behavior with existing social links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)