### PR TITLE
fix: preserve member joined_at dates when updating project members

### DIFF
--- a/apps/codebility/app/home/my-team/[projectId]/_components/TeamDetailView.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/_components/TeamDetailView.tsx
@@ -34,13 +34,10 @@ import { getMeetingSchedule, getTeamMonthlyAttendancePoints } from "../actions";
  * ✅ Manage Members button: Only visible to team leads (in Team View)
  * 
  * BEHAVIOR:
-
  * - Regular members: Can view attendance but cannot edit
  * - Team leads: Full edit access to attendance
-
  * - Regular members: See only Team View tab (read-only)
  * - Team leads: Full control over all team management features
-
  */
 
 interface ProjectData {
@@ -219,23 +216,15 @@ const TeamDetailView = ({ projectData }: TeamDetailViewProps) => {
       if (result.success) {
         toast.success("Project members updated successfully.");
 
-        const updatedProjectMembers: SimpleMemberData[] = selectedMembers
-          .filter(member => member.id !== teamLead.id)
-          .map(member => ({
-            id: member.id,
-            first_name: member.first_name,
-            last_name: member.last_name,
-            email_address: member.email_address,
-            image_url: member.image_url ?? null,
-            role: 'member',
-            display_position: member.display_position ?? null,
-            joined_at: new Date().toISOString(),
+        // ✅ FIXED: Re-fetch members to get accurate joined_at dates from database
+        const updatedMembersResult = await getMembers(projectInfo.id);
+        
+        if (updatedMembersResult.data) {
+          setProject(prev => ({
+            ...prev,
+            members: { data: updatedMembersResult.data }
           }));
-
-        setProject(prev => ({
-          ...prev,
-          members: { data: updatedProjectMembers }
-        }));
+        }
 
         handleCloseModal();
       } else {


### PR DESCRIPTION
- Modified updateProjectMembers() to fetch and preserve existing dates
- Modified updateProject() to use preserved timestamps
- Fixed TeamDetailView optimistic update to re-fetch from database
- Prevents data loss when adding new members
- New members get current timestamp, existing keep original dates

<img width="554" height="439" alt="Screenshot 2025-12-16 at 9 45 53 PM" src="https://github.com/user-attachments/assets/50774952-5c50-429d-b5dc-30fba0937229" />


<img width="1001" height="734" alt="Screenshot 2025-12-16 at 9 06 32 PM" src="https://github.com/user-attachments/assets/8fb24b72-2384-4956-82f3-c006a0b201e2" />
