### PR TITLE
Fixed Updating Issue in Profile Educational Background Info

### DIFF
--- a/apps/codebility/app/home/settings/profile/_components/EducationalBackground.tsx
+++ b/apps/codebility/app/home/settings/profile/_components/EducationalBackground.tsx
@@ -120,7 +120,7 @@ const EducationalBackground = ({ data, codevId }: EducationProps) => {
     }
 
     return true;
-  }, [educationData]);
+  }, []);
 
   // Check if there are no education entries or all are empty
   const hasNoEducation = educationData.length === 0;
@@ -221,7 +221,10 @@ const EducationForm = ({
       !education.start_date &&
       !education.end_date;
 
-    handleEditModePerItem(itemNo, isNewEmpty);
+    if (isNewEmpty) {
+      handleEditModePerItem(itemNo, true);
+      setEditMode(true);
+    }
   }, [education, handleEditModePerItem, itemNo, totalNo]);
 
   useEffect(() => {
@@ -250,8 +253,8 @@ const EducationForm = ({
       achievements: education.achievements || null,
       start_date: education.start_date || null,
       end_date: education.end_date || null,
-      codev_id: education.codev_id,
-      profile_id: education.profile_id,
+      codev_id: education.codev_id || undefined,
+      profile_id: education.profile_id || undefined,
     };
 
     try {
@@ -292,7 +295,10 @@ const EducationForm = ({
         {!editMode && (
           <IconEdit
             onClick={() => {
-              if (!isLoadingMain) setEditMode(true);
+              if (!isLoadingMain) {
+                handleEditModePerItem(itemNo, true);
+                setEditMode(true);
+              }
             }}
             className="cursor-pointer invert dark:invert-0"
           />


### PR DESCRIPTION
### Fix: Educational Background Form Refuses to Accept Data Updates

**Problem:**
- Form fields remained disabled after clicking the Edit button
- Changes to education data were not being saved
- TypeScript type mismatch causing save failures

**Solution:**
- Fixed edit mode synchronization by updating both local state and ref when Edit button is clicked
- Properly initialized edit mode for new empty education entries
- Changed `codev_id` and `profile_id` to use `undefined` instead of `null` to match TypeScript type definitions

**Changes:**
- Updated `IconEdit` onClick handler to call `handleEditModePerItem(itemNo, true)` before `setEditMode(true)`
- Added `setEditMode(true)` in the first useEffect for new empty items
- Modified `handleSaveAndUpdate` to use `undefined` for empty UUID fields instead of `null`

This ensures the edit mode state stays synchronized between the component state and the ref, allowing users to properly edit and save their educational background information.