### PR TITLE
Fix Codevs Filter Dropdown Z-Index Visibility fix codevs filter dropdown

### DIFF
--- a/apps/codebility/app/home/interns/_components/FilterCodevs.tsx
+++ b/apps/codebility/app/home/interns/_components/FilterCodevs.tsx
@@ -77,8 +77,17 @@ export default function FilterCodevs({
   useEffect(() => {
     if (buttonRef && showFilter) {
       const rect = buttonRef.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      const dropdownHeight = 450; // Approximate dropdown height
+      
+      // Check if dropdown would overflow bottom of viewport
+      const wouldOverflowBottom = rect.bottom + dropdownHeight > viewportHeight;
+      
       setDropdownPosition({
-        top: rect.bottom + 8, // 8px gap below button
+        // Position above button if would overflow, otherwise below
+        top: wouldOverflowBottom 
+          ? Math.max(60, rect.top - dropdownHeight - 8) // Above with top padding
+          : rect.bottom + 8, // Below with gap
         right: window.innerWidth - rect.right, // Align right edge
       });
     }
@@ -118,7 +127,7 @@ export default function FilterCodevs({
         
         {/* Filter dropdown panel */}
         <div
-          className="fixed z-50 max-h-[calc(100vh-6rem)] min-h-[300px] w-[90vw] overflow-auto
+          className="fixed z-50 max-h-[min(70vh,500px)] min-h-[300px] w-[90vw] overflow-auto
             sm:w-96 md:w-80 rounded-2xl bg-white/95 backdrop-blur-md p-6 shadow-2xl 
             dark:bg-gray-900/95 border border-gray-200 dark:border-gray-700"
           style={{


### PR DESCRIPTION
# PR Summary: Fix Codevs Filter Dropdown Z-Index Visibility

## Branch
`fix/codevs-filter-visibility-z-index`

## Problem
Filter dropdown in Codevs tab was rendering beneath codev member cards, making it partially or fully hidden when opened.

## Root Cause
- Filter dropdown used `z-[1]` which was insufficient
- Trapped in parent stacking context
- Codev cards had higher z-index priority

## Solution
**Single File Modified:**
- `apps/codebility/app/home/interns/_components/FilterCodevs.tsx`

<img width="1308" height="750" alt="Screenshot 2025-12-23 at 11 38 35 PM" src="https://github.com/user-attachments/assets/d189d376-158a-4705-bcd1-db52616ddb7a" />


**Key Changes:**
1. **Portal Rendering** - Dropdown now renders to `document.body` using `createPortal`, escaping all parent stacking contexts
2. **Z-Index Fix** - Increased to `z-50` (dropdown) + `z-40` (backdrop overlay)
3. **Dynamic Positioning** - Calculates dropdown position relative to button using refs
4. **Click-Outside Close** - Added backdrop overlay to close filter when clicking outside
5. **Dark Mode Support** - Full light/dark theme consistency

## Technical Details
- Uses React `createPortal` for proper layering
- Fixed positioning relative to viewport
- Backdrop prevents interaction with page while filter is open
- Responsive: 90vw mobile, 384px tablet, 320px desktop

<img width="1389" height="914" alt="Screenshot 2025-12-23 at 11 38 24 PM" src="https://github.com/user-attachments/assets/58d301b9-ebb9-438d-9a53-a3fea1eae65d" />

## Testing
- [x] Filter opens above codev cards
- [x] Click outside closes dropdown
- [x] All filter checkboxes functional (Position/Status/Projects)
- [x] Dark mode works correctly
- [x] Mobile responsive layout
- [x] "Clear all" button works

## Visual Result
Filter dropdown now properly overlays all content with no visibility issues.

---
**Ready for review** @Guo-Alyssa-Lyn