### PR TITLE
PR Summary: Fix Team Lead Avatar Consistency in Kanban Projects

### DIFF
--- a/apps/codebility/app/home/interns/_components/CodevCard.tsx
+++ b/apps/codebility/app/home/interns/_components/CodevCard.tsx
@@ -19,6 +19,9 @@ import { Badge } from "@codevs/ui/badge";
 
 import TechStacks from "./TechStacks";
 
+// Line 21: ADDED - Maximum visible projects to prevent card expansion (CBP-10)
+const MAX_VISIBLE_PROJECTS = 8;
+
 interface CodevCardProps {
   codev: Codev;
 }
@@ -199,20 +202,30 @@ export default function CodevCard({ codev }: CodevCardProps) {
             )}
           </div>
 
-          {/* Projects */}
+          {/* Line 217-243: FIXED Projects section with truncation (CBP-10) */}
           <div className="mt-auto flex flex-wrap justify-end gap-2">
             {hasItems(codev.projects) ? (
-              codev.projects.map((project) => (
-                <Badge
-                  variant="info"
-                  key={project.id}
-                  className="from-customBlue-600 hover:from-customBlue-700 dark:from-customBlue-500 dark:hover:from-customBlue-600 rounded-full bg-gradient-to-r to-indigo-600 px-3 py-1 text-xs font-medium
-                    text-white transition-all duration-300 hover:to-indigo-700 dark:to-indigo-500 dark:hover:to-indigo-600
-                  "
-                >
-                  {project.name}
-                </Badge>
-              ))
+              <>
+                {/* Line 220-231: CHANGED - Render only first MAX_VISIBLE_PROJECTS badges */}
+                {codev.projects.slice(0, MAX_VISIBLE_PROJECTS).map((project) => (
+                  <Badge
+                    variant="info"
+                    key={project.id}
+                    className="from-customBlue-600 hover:from-customBlue-700 dark:from-customBlue-500 dark:hover:from-customBlue-600 rounded-full bg-gradient-to-r to-indigo-600 px-3 py-1 text-xs font-medium
+                      text-white transition-all duration-300 hover:to-indigo-700 dark:to-indigo-500 dark:hover:to-indigo-600
+                    "
+                  >
+                    {project.name}
+                  </Badge>
+                ))}
+                
+                {/* Line 233-239: ADDED - "+X more" overflow indicator */}
+                {codev.projects.length > MAX_VISIBLE_PROJECTS && (
+                  <span className="self-center text-xs font-medium text-gray-500 dark:text-gray-400">
+                    +{codev.projects.length - MAX_VISIBLE_PROJECTS} more
+                  </span>
+                )}
+              </>
             ) : (
               <Badge
                 variant="info"

--- a/apps/codebility/app/home/kanban/page.tsx
+++ b/apps/codebility/app/home/kanban/page.tsx
@@ -187,19 +187,21 @@ export default async function KanbanPage(props: PageProps) {
               </span>
             </TableCell>
 
-            {/* Team Lead */}
+            {/* Team Lead - ENHANCED with Default Avatar Fallback */}
             <TableCell className="md:table-cell">
               {project.team_leader ? (
                 <div className="flex items-center gap-2">
-                  {project.team_leader.image_url && (
-                    <img
-                      src={project.team_leader.image_url}
-                      alt={`${project.team_leader.first_name}'s avatar`}
-                      className={`h-8 w-8 rounded-full object-cover ${
-                        project.isUserInvolved ? "" : "opacity-50 grayscale"
-                      }`}
-                    />
-                  )}
+                  {/* ✅ FIXED: Always render image with default avatar fallback */}
+                  <img
+                    src={
+                      project.team_leader.image_url ||
+                      "https://codebility-cdn.pages.dev/assets/images/default-avatar-200x200.jpg"
+                    }
+                    alt={`${project.team_leader.first_name}'s avatar`}
+                    className={`h-8 w-8 rounded-full object-cover ${
+                      project.isUserInvolved ? "" : "opacity-50 grayscale"
+                    }`}
+                  />
                   <span
                     className={`capitalize ${
                       project.isUserInvolved


### PR DESCRIPTION
Problem
Team Lead avatars in Kanban Projects view showed inconsistent behavior:
* Team leads without profile images → Name only (no placeholder) ❌
This created visual inconsistency in the Team Lead column.
Solution
Replace conditional rendering with fallback to default avatar URL.

<img width="1130" height="381" alt="Screenshot 2026-01-08 at 9 40 01 PM" src="https://github.com/user-attachments/assets/09e2a2d8-6531-4dbb-bcbd-12e5f30afa6e" />
