### PR TITLE
miguel/ career categories layout

### DIFF
--- a/apps/codebility/app/(marketing)/careers/_components/JobListings.tsx
+++ b/apps/codebility/app/(marketing)/careers/_components/JobListings.tsx
@@ -155,7 +155,7 @@ export default function JobListings() {
               </div>
 
               {/* Job Type Filter */}
-              <div className="pb-4 lg:col-span-4 lg:pb-4">
+              <div className="pb-4 lg:col-span-4 lg:pb-4 ml-[-35px]">
                 <label className="mb-2 block text-sm font-medium text-gray-300">Job Type</label>
                 <div className="flex flex-wrap gap-2">
                   {types.map((type) => (


### PR DESCRIPTION
Change: on large screens, categories are arranged horizontally
<img width="1324" height="275" alt="image" src="https://github.com/user-attachments/assets/c86c9bf6-bb63-4139-a4fc-d466e1c6a569" />
<img width="621" height="421" alt="image" src="https://github.com/user-attachments/assets/e19f18eb-32f2-41c3-a0c7-aff8a1beb344" />
