### PR TITLE
fix(applicant): update GitHub URL validation to allow .git suffix

### DIFF
--- a/apps/codebility/app/applicant/waiting/_components/applicantStep2.tsx
+++ b/apps/codebility/app/applicant/waiting/_components/applicantStep2.tsx
@@ -154,7 +154,7 @@ function PostReadInstructions({
       if (user?.display_position.includes("UI/UX Designer") === false) {
         //validate the fork url
         const urlPattern =
-          /^(https?:\/\/)?(www\.)?github\.com\/[a-zA-Z0-9_-]+\/codebility-assessment(\/.*)?$/;
+          /^(https?:\/\/)?(www\.)?github\.com\/[a-zA-Z0-9_-]+\/codebility-assessment(\.git)?(\/.*)?$/;
 
         if (!urlPattern.test(data.fork_url)) {
           throw new Error(
@@ -286,7 +286,7 @@ function PostSubmitted({
       if (user?.display_position.includes("UI/UX Designer") === false) {
         //validate the fork url
         const urlPattern =
-          /^(https?:\/\/)?(www\.)?github\.com\/[a-zA-Z0-9_-]+\/codebility-assessment(\/.*)?$/;
+          /^(https?:\/\/)?(www\.)?github\.com\/[a-zA-Z0-9_-]+\/codebility-assessment(\.git)?(\/.*)?$/;
 
         if (!urlPattern.test(data.fork_url)) {
           throw new Error(


### PR DESCRIPTION
**PR Notes: GitHub Repository Link Validation Fix**

**1. Bug Identification**
The issue was identified via a screenshot showing an applicant attempting to submit a GitHub repository URL: https://github.com/Jeserry-Rodcliffe/codebility-assessment.git

The UI was returning a validation error: "_Please enter a valid GitHub repository URL_".

By analyzing the source code in 

**apps/codebility/app/applicant/waiting/_components/applicantStep2.tsx**, I found that the **urlPattern** regex was too restrictive:

typescript
// Old Regex
const urlPattern = /^(https?:\/\/)?(www\.)?github\.com\/[a-zA-Z0-9_-]+\/codebility-assessment(\/.*)?$/;
This regex required the URL to end exactly with the repository name codebility-assessment, whereas GitHub's clone link (which many applicants copy) includes a .git suffix.

**2. Reproduction**
I created a test script to validate the reported link against the existing regex:

Link: .../codebility-assessment.git
Result: FAIL (Confirmed the bug).

**3. Fix Implementation**
I updated the regular expression in two components within 

applicantStep2.tsx
 (

PostReadInstructions
 and 

PostSubmitted
):

typescript
// New Regex
const urlPattern = /^(https?:\/\/)?(www\.)?github\.com\/[a-zA-Z0-9_-]+\/codebility-assessment(\.git)?(\/.*)?$/;
Added 

(.git)?
 to the pattern to make the .git suffix optional but valid.

**4. Verification**
Standalone Test: Validated the new regex against the failing link. Result: PASS.
UI Test: Bypassed middleware and mocked user state to test the form live in the browser. The validation error no longer appears when pasting .git links.
Compatibility: Verified the fix does not break standard GitHub links (without .git) or UI/UX Designer Figma links.

**5. Final Changes**
File Modified: 

apps/codebility/app/applicant/waiting/_components/applicantStep2.tsx
Branch: **githublink/juryyy**
Commit: fix(applicant): update GitHub URL validation to allow .git suffix
<img width="1920" height="1080" alt="Screenshot (889)" src="https://github.com/user-attachments/assets/4d95467f-44eb-4676-b60e-7ffc777b5293" />
