### PR TITLE
 CBP-116: Sublead Selection

### DIFF
--- a/apps/codebility/app/home/projects/_components/ProjectEditModal.tsx
+++ b/apps/codebility/app/home/projects/_components/ProjectEditModal.tsx
@@ -4,7 +4,7 @@ import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import {
-  getProjectByID,           // ← ADDED: fetch full project data with project_members
+  getProjectByID,
   getProjectCategories,
   getProjectClients,
   getProjectCodevs,
@@ -33,13 +33,11 @@ import toast from "react-hot-toast";
 import { Button } from "@codevs/ui/button";
 import { Input } from "@codevs/ui/input";
 
-// Dynamically import the ImageCrop component with no SSR
 const ImageCrop = dynamic(() => import("./ImageCrop"), {
   ssr: false,
   loading: () => <Skeleton className="h-48 w-full rounded-lg" />,
 });
 
-// Define the available project statuses.
 const PROJECT_STATUSES = [
   { id: "pending", value: "pending", label: "Pending" },
   { id: "inprogress", value: "inprogress", label: "In Progress" },
@@ -77,9 +75,12 @@ const ProjectEditModal = () => {
   // Data states
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
   const [currentTeamLeader, setCurrentTeamLeader] = useState<Codev | null>(null);
+  // ── CBP-116: sublead state ────────────────────────────────────────────────
+  const [currentSubLead, setCurrentSubLead] = useState<Codev | null>(null);
+  // ─────────────────────────────────────────────────────────────────────────
   const [selectedMembers, setSelectedMembers] = useState<Codev[]>([]);
 
-  // Image states with optimized loading
+  // Image states
   const [projectImage, setProjectImage] = useState<string | null>(null);
   const [openImageCropper, setOpenImageCropper] = useState(false);
   const [croppedImage, setCroppedImage] = useState<string | null>(null);
@@ -92,7 +93,6 @@ const ProjectEditModal = () => {
   // Loading states
   const [isLoading, setIsLoading] = useState(false);
 
-  // Controlled status state
   const [selectedStatus, setSelectedStatus] = useState<string>(data?.status || "pending");
 
   const {
@@ -103,7 +103,6 @@ const ProjectEditModal = () => {
     formState: { errors },
   } = useForm<ProjectFormData>({ mode: "onChange" });
 
-  // Fetch users data with React Query
   const { data: users = [], isLoading: isUsersLoading } = useQuery({
     queryKey: ["projectCodevs"],
     queryFn: async () => {
@@ -114,7 +113,6 @@ const ProjectEditModal = () => {
     refetchOnWindowFocus: false,
   });
 
-  // Fetch clients data with React Query
   const { data: clients = [], isLoading: isClientsLoading } = useQuery({
     queryKey: ["projectClients"],
     queryFn: async () => {
@@ -125,7 +123,6 @@ const ProjectEditModal = () => {
     refetchOnWindowFocus: false,
   });
 
-  // Fetch categories data with React Query
   const { data: categories = [], isLoading: isCategoriesLoading } = useQuery({
     queryKey: ["projectCategories"],
     queryFn: async () => {
@@ -136,11 +133,9 @@ const ProjectEditModal = () => {
     refetchOnWindowFocus: false,
   });
 
-  // ─── FIX: Fetch full project data when modal opens ───────────────────────
-  // The modal hook's `data` object comes from the projects list query, which
-  // does NOT include project_members. getProjectByID returns the full shape
-  // including project_members with codev_id + role, which is needed to
-  // pre-populate the team leader and members selects.
+  // Fetch full project data (with project_members) when modal opens.
+  // The projects list query does NOT join project_members, so we need this
+  // separate fetch to pre-populate team leader, sublead, and members.
   const { data: fullProjectData, isLoading: isFullProjectLoading } = useQuery({
     queryKey: ["projectFull", data?.id],
     queryFn: async () => {
@@ -148,16 +143,14 @@ const ProjectEditModal = () => {
       const result = await getProjectByID(data.id);
       return result;
     },
-    enabled: !!data?.id && isModalOpen,   // only fetch when modal is open
-    staleTime: 0,                          // always fresh on open
+    enabled: !!data?.id && isModalOpen,
+    staleTime: 0,
     refetchOnWindowFocus: false,
   });
-  // ─────────────────────────────────────────────────────────────────────────
 
   const isSelectDataLoading =
     isUsersLoading || isClientsLoading || isCategoriesLoading || isFullProjectLoading;
 
-  // Prepare select options using useMemo
   const userOptions = useMemo(
     () =>
       users.map((user) => ({
@@ -182,39 +175,33 @@ const ProjectEditModal = () => {
     [clients],
   );
 
-  // ─── FIX: Inject team leader into dropdown if not in getProjectCodevs() ──
-  // getProjectCodevs() may exclude users due to RLS or internal_status.
-  // If the current team leader is absent from userOptions, the CustomSelect
-  // has no matching option — the dropdown won't display their name even when
-  // value is set correctly. We inject them from fullProjectData.project_members
-  // which always returns their codev data via the getProjectByID join.
+  // Inject ANY project member absent from getProjectCodevs() into dropdown options.
+  // getProjectCodevs() may exclude users due to RLS or internal_status filtering.
+  // We use fullProjectData.project_members (from getProjectByID join) as the
+  // source of truth — it always returns codev data regardless of RLS.
+  // This covers the team leader (CBP-95) and any member used as sublead (CBP-116).
   const enhancedUserOptions = useMemo(() => {
     if (!fullProjectData?.project_members) return userOptions;
 
-    const teamLeaderMember = fullProjectData.project_members.find(
-      (pm: any) => pm.role === "team_leader",
-    );
-    if (!teamLeaderMember?.codev) return userOptions;
+    // Build a set of codev_ids already present in userOptions for O(1) lookup
+    const existingIds = new Set(userOptions.map((opt) => opt.value));
 
-    // Already in the list — no injection needed
-    const alreadyInList = userOptions.find(
-      (opt) => opt.value === teamLeaderMember.codev_id,
-    );
-    if (alreadyInList) return userOptions;
+    // Collect all project members missing from userOptions
+    const missingMembers = fullProjectData.project_members
+      .filter((pm: any) => pm.codev && !existingIds.has(pm.codev_id))
+      .map((pm: any) => ({
+        id: pm.codev_id,
+        value: pm.codev_id,
+        label: `${pm.codev.first_name} ${pm.codev.last_name}`,
+        subLabel: pm.codev.display_position || "",
+        imageUrl: pm.codev.image_url || null,
+      }));
 
-    // Inject the team leader at the top of the list
-    return [
-      {
-        id: teamLeaderMember.codev_id,
-        value: teamLeaderMember.codev_id,
-        label: `${teamLeaderMember.codev.first_name} ${teamLeaderMember.codev.last_name}`,
-        subLabel: teamLeaderMember.codev.display_position || "",
-        imageUrl: teamLeaderMember.codev.image_url || null,
-      },
-      ...userOptions,
-    ];
+    if (missingMembers.length === 0) return userOptions;
+
+    // Inject missing members at the top so they are always findable
+    return [...missingMembers, ...userOptions];
   }, [userOptions, fullProjectData]);
-  // ─────────────────────────────────────────────────────────────────────────
 
   // Populate basic form fields when modal opens
   useEffect(() => {
@@ -256,29 +243,21 @@ const ProjectEditModal = () => {
     }
   }, [data, setValue, isModalOpen, setStack, clearStack]);
 
-  // ─── FIX: Initialize team leader + members from fullProjectData ──────────
-  // Uses fullProjectData (from getProjectByID) instead of data.project_members
-  // which is always undefined from the list query.
-  //
-  // Team leader lookup order:
-  //   1. Find in users array (from getProjectCodevs)
-  //   2. Fall back to codev data embedded in fullProjectData.project_members
-  //      — handles the case where the leader is filtered out of getProjectCodevs
-  //      (e.g. RLS policy, internal_status). Requires display_position and
-  //      email_address to be selected in getProjectByID's codev sub-select.
+  // Pre-populate team leader, sublead, and members from fullProjectData.
+  // fullProjectData comes from getProjectByID which includes project_members.
+  // The list page query does not join project_members so we cannot use data directly.
   useEffect(() => {
     if (!fullProjectData || !isModalOpen) return;
 
     const projectMembers = fullProjectData.project_members;
     if (!projectMembers?.length) return;
 
-    // ── Team leader ──────────────────────────────────────────────────────
+    // ── Team leader ──────────────────────────────────────────────────────────
     const teamLeaderMember = projectMembers.find(
       (pm: any) => pm.role === "team_leader",
     );
 
     if (teamLeaderMember) {
-      // Primary: find in users (full Codev object)
       const leaderFromUsers = users.find(
         (user) => user.id === teamLeaderMember.codev_id,
       );
@@ -286,11 +265,8 @@ const ProjectEditModal = () => {
       if (leaderFromUsers) {
         setCurrentTeamLeader(leaderFromUsers);
       } else if (teamLeaderMember.codev) {
-        // Fallback: construct minimal Codev from embedded project_members data.
-        // Requires getProjectByID to select display_position + email_address
-        // on the codev sub-relation (see actions.ts patch).
-        // Cast via unknown: Codev has fields we don't have here (username, etc.)
-        // but we only need this object for dropdown display — id + name + image.
+        // Fallback: build minimal Codev from embedded data when the leader
+        // is absent from getProjectCodevs() (RLS / internal_status filtered).
         setCurrentTeamLeader({
           id: teamLeaderMember.codev_id,
           first_name: teamLeaderMember.codev.first_name,
@@ -304,16 +280,46 @@ const ProjectEditModal = () => {
       }
     }
 
-    // ── Regular members ──────────────────────────────────────────────────
+    // ── CBP-116: Sublead pre-population ───────────────────────────────────────
+    const subLeadMember = projectMembers.find(
+      (pm: any) => pm.role === "sublead",
+    );
+
+    if (subLeadMember) {
+      // Primary: find full Codev object from users list
+      const subLeadFromUsers = users.find(
+        (user) => user.id === subLeadMember.codev_id,
+      );
+
+      if (subLeadFromUsers) {
+        setCurrentSubLead(subLeadFromUsers);
+      } else if (subLeadMember.codev) {
+        // Fallback: build minimal Codev from embedded data (same pattern as team leader)
+        setCurrentSubLead({
+          id: subLeadMember.codev_id,
+          first_name: subLeadMember.codev.first_name,
+          last_name: subLeadMember.codev.last_name,
+          image_url: subLeadMember.codev.image_url || null,
+          display_position: subLeadMember.codev.display_position || null,
+          email_address: subLeadMember.codev.email_address || "",
+          positions: [],
+          tech_stacks: [],
+        } as unknown as Codev);
+      }
+    } else {
+      // No sublead on this project — reset to null when reopening modal
+      setCurrentSubLead(null);
+    }
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ── Regular members ──────────────────────────────────────────────────────
     const memberIds = projectMembers
       .filter((pm: any) => pm.role === "member")
       .map((pm: any) => pm.codev_id);
 
     setSelectedMembers(users.filter((user) => memberIds.includes(user.id)));
   }, [fullProjectData, users, isModalOpen]);
-  // ─────────────────────────────────────────────────────────────────────────
 
-  // Handler for image change
   const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
     try {
       setImageLoaded(false);
@@ -329,7 +335,6 @@ const ProjectEditModal = () => {
     }
   };
 
-  // Handler for image removal
   const handleRemoveImage = () => {
     setProjectImage(null);
     setValue("main_image", undefined);
@@ -346,6 +351,7 @@ const ProjectEditModal = () => {
     setGalleryImages([]);
     setSelectedMembers([]);
     setCurrentTeamLeader(null);
+    setCurrentSubLead(null); // ── CBP-116
     setImageLoaded(false);
     clearStack();
     onClose();
@@ -650,14 +656,15 @@ const ProjectEditModal = () => {
           Team Configuration
         </h4>
 
-        {/* Show skeleton while loading full project data or users */}
         {isFullProjectLoading || isUsersLoading ? (
           <div className="space-y-3">
+            <Skeleton className="h-10 w-full rounded-lg" />
             <Skeleton className="h-10 w-full rounded-lg" />
             <Skeleton className="h-10 w-full rounded-lg" />
           </div>
         ) : (
           <div className="space-y-6">
+            {/* Team Leader */}
             <div className="space-y-1">
               <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
                 Team Leader *
@@ -677,12 +684,88 @@ const ProjectEditModal = () => {
               />
             </div>
 
+            {/* ── CBP-116: Sublead selector ─────────────────────────────────────
+                Optional — no asterisk, no toast validation required.
+                Excluded from members list and excluded from team leader list.
+                Clearing the select (empty string value) sets sublead to null.
+            ──────────────────────────────────────────────────────────────────── */}
+            <div className="space-y-1">
+              <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+                Sub Lead{" "}
+                <span className="font-normal text-gray-500 dark:text-gray-400">
+                  (Optional — acts as team lead when lead is unavailable)
+                </span>
+              </label>
+              <CustomSelect
+                options={[
+                  // "None" option — value must not be empty string (Radix UI Select.Item constraint)
+                  { id: "none", value: "none", label: "No sublead assigned", subLabel: "" },
+                  // Only show members of this project, excluding the team leader.
+                  // Source: fullProjectData.project_members (bypasses RLS filtering
+                  // that drops some users from getProjectCodevs results).
+                  ...(fullProjectData?.project_members ?? [])
+                    .filter(
+                      (pm: any) =>
+                        pm.codev &&
+                        pm.codev_id !== currentTeamLeader?.id &&
+                        pm.role !== "team_leader",
+                    )
+                    .map((pm: any) => ({
+                      id: pm.codev_id,
+                      value: pm.codev_id,
+                      label: `${pm.codev.first_name} ${pm.codev.last_name}`,
+                      subLabel: pm.codev.display_position || "",
+                      imageUrl: pm.codev.image_url || null,
+                    })),
+                ]}
+                value={currentSubLead?.id || "none"}
+                onChange={(value) => {
+                  if (!value || value === "none") {
+                    // User selected "None" — clear the sublead
+                    setCurrentSubLead(null);
+                    return;
+                  }
+                  // Find in users first, fall back to project_members embedded data
+                  const subLeadFromUsers = users.find((u) => u.id === value);
+                  if (subLeadFromUsers) {
+                    setCurrentSubLead(subLeadFromUsers);
+                    return;
+                  }
+                  // Fallback: construct from fullProjectData (handles RLS-filtered users)
+                  const subLeadMember = fullProjectData?.project_members?.find(
+                    (pm: any) => pm.codev_id === value,
+                  );
+                  if (subLeadMember?.codev) {
+                    setCurrentSubLead({
+                      id: subLeadMember.codev_id,
+                      first_name: subLeadMember.codev.first_name,
+                      last_name: subLeadMember.codev.last_name,
+                      image_url: subLeadMember.codev.image_url || null,
+                      display_position: subLeadMember.codev.display_position || null,
+                      email_address: subLeadMember.codev.email_address || "",
+                      positions: [],
+                      tech_stacks: [],
+                    } as unknown as Codev);
+                  }
+                }}
+                placeholder="Select Sub Lead"
+                disabled={isUsersLoading}
+                searchable
+              />
+            </div>
+            {/* ─────────────────────────────────────────────────────────────── */}
+
+            {/* Team Members */}
             <div className="space-y-1">
               <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
                 Team Members
               </label>
               <MemberSelection
-                users={users.filter((user) => user.id !== currentTeamLeader?.id)}
+                users={users.filter(
+                  (user) =>
+                    user.id !== currentTeamLeader?.id &&
+                    user.id !== currentSubLead?.id, // exclude sublead from member pool
+                )}
                 selectedMembers={selectedMembers}
                 onMemberAdd={(member) =>
                   setSelectedMembers((prev) => [...prev, member])
@@ -690,7 +773,10 @@ const ProjectEditModal = () => {
                 onMemberRemove={(memberId) =>
                   setSelectedMembers((prev) => prev.filter((m) => m.id !== memberId))
                 }
-                excludeMembers={currentTeamLeader ? [currentTeamLeader.id] : []}
+                excludeMembers={[
+                  ...(currentTeamLeader ? [currentTeamLeader.id] : []),
+                  ...(currentSubLead ? [currentSubLead.id] : []), // ── CBP-116
+                ]}
                 showLabel={false}
               />
             </div>
@@ -805,19 +891,29 @@ const ProjectEditModal = () => {
 
       form.set("status", selectedStatus);
 
+        // ── CBP-116: Build project members array including sublead if set ────────
       const projectMembers = [
         { codev_id: currentTeamLeader.id, role: "team_leader" },
-        ...selectedMembers.map((member) => ({ codev_id: member.id, role: "member" })),
+        // Only include sublead row if a sublead was selected
+        ...(currentSubLead
+          ? [{ codev_id: currentSubLead.id, role: "sublead" }]
+          : []),
+        // Filter sublead out of members — they may be an existing member promoted
+        // to sublead. Without this filter they'd get two rows: sublead + member.
+        ...selectedMembers
+          .filter((member) => member.id !== currentSubLead?.id)
+          .map((member) => ({ codev_id: member.id, role: "member" })),
       ];
+      // ─────────────────────────────────────────────────────────────────────────
 
       form.append("project_members", JSON.stringify(projectMembers));
 
       const response = await updateProject(data.id, form);
       if (response.success) {
-        // Invalidate all relevant queries so view modal and list reflect new data
         queryClient.invalidateQueries({ queryKey: ["teamLead", data.id] });
         queryClient.invalidateQueries({ queryKey: ["members", data.id] });
         queryClient.invalidateQueries({ queryKey: ["projectFull", data.id] });
+        queryClient.invalidateQueries({ queryKey: ["subLead", data.id] }); // ── CBP-116
         toast.success("Project updated successfully!");
         onClose();
       } else {
@@ -842,7 +938,6 @@ const ProjectEditModal = () => {
 
         <div className="flex-1 overflow-y-auto p-3" style={{ maxHeight: "calc(80vh - 200px)" }}>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            {/* Project Image Section */}
             <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
               <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
@@ -853,7 +948,6 @@ const ProjectEditModal = () => {
               <ImageUploadSection />
             </div>
 
-            {/* Project Details Section */}
             <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
               <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
@@ -864,7 +958,6 @@ const ProjectEditModal = () => {
               <ProjectDetailsSection />
             </div>
 
-            {/* Team & Configuration Section */}
             <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
               <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">

--- a/apps/codebility/app/home/projects/_components/ProjectViewModal.tsx
+++ b/apps/codebility/app/home/projects/_components/ProjectViewModal.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   getMembers,
+  getSubLead,   // ── CBP-116
   getTeamLead,
   SimpleMemberData,
 } from "@/app/home/projects/actions";
@@ -23,14 +24,11 @@ import { IconFigma } from "@/public/assets/svgs/techstack";
 import { useQuery } from "@tanstack/react-query";
 import { format, parseISO } from "date-fns";
 
-// Note: Project categories are now fetched directly from the project data
-// No need for hardcoded mapping since categories are included in the project object
-
 const ProjectViewModal = () => {
   const { isOpen, type, onClose, onOpen, data } = useModal();
   const isModalOpen = isOpen && type === "projectViewModal";
 
-  // Using React Query to fetch team lead data
+  // Fetch team lead
   const { data: teamLead, isLoading: isTeamLeadLoading } = useQuery({
     queryKey: ["teamLead", data?.id],
     queryFn: async () => {
@@ -43,7 +41,21 @@ const ProjectViewModal = () => {
     refetchOnWindowFocus: false,
   });
 
-  // Using React Query to fetch members data
+  // ── CBP-116: Fetch sublead — optional, null when none assigned ────────────
+  const { data: subLead, isLoading: isSubLeadLoading } = useQuery({
+    queryKey: ["subLead", data?.id],
+    queryFn: async () => {
+      if (!data?.id) return null;
+      const result = await getSubLead(data.id);
+      return result.data;
+    },
+    enabled: !!data?.id && isModalOpen,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+  // ─────────────────────────────────────────────────────────────────────────
+
+  // Fetch members
   const { data: members = [], isLoading: isMembersLoading } = useQuery({
     queryKey: ["members", data?.id],
     queryFn: async () => {
@@ -56,9 +68,8 @@ const ProjectViewModal = () => {
     refetchOnWindowFocus: false,
   });
 
-  const isLoading = isTeamLeadLoading || isMembersLoading;
+  const isLoading = isTeamLeadLoading || isSubLeadLoading || isMembersLoading;
 
-  // Format dates if available.
   const startDate = data?.start_date
     ? format(parseISO(data.start_date), "MM/dd/yyyy")
     : null;
@@ -69,7 +80,6 @@ const ProjectViewModal = () => {
     ? format(parseISO(data.created_at), "MM/dd/yyyy hh:mm:ss a")
     : null;
 
-  // Image loading optimization
   const [imageLoaded, setImageLoaded] = useState(false);
 
   return (
@@ -138,7 +148,6 @@ const ProjectViewModal = () => {
               </h3>
 
               <div className="grid gap-6 md:grid-cols-2">
-                {/* Project Details */}
                 <div className="space-y-4">
                   <div>
                     <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
@@ -154,8 +163,7 @@ const ProjectViewModal = () => {
                       Tagline
                     </h4>
                     <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
-                      {data?.tagline ||
-                        "Innovative solutions for modern challenges"}
+                      {data?.tagline || "Innovative solutions for modern challenges"}
                     </p>
                   </div>
 
@@ -175,13 +183,12 @@ const ProjectViewModal = () => {
                       Key Features
                     </h4>
                     <div className="space-y-1">
-                      {(data?.key_features && Array.isArray(data.key_features) && data.key_features.length > 0
-                        ? data.key_features
-                        : [
-                            "Responsive Design",
-                            "Modern UI/UX",
-                            "Cross-platform Compatibility",
-                          ]
+                      {(
+                        data?.key_features &&
+                        Array.isArray(data.key_features) &&
+                        data.key_features.length > 0
+                          ? data.key_features
+                          : ["Responsive Design", "Modern UI/UX", "Cross-platform Compatibility"]
                       ).map((feature, index) => (
                         <div key={index} className="flex items-start gap-2">
                           <span className="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500"></span>
@@ -193,7 +200,6 @@ const ProjectViewModal = () => {
                     </div>
                   </div>
 
-                  {/* External Links */}
                   <div>
                     <h4 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
                       External Links
@@ -229,18 +235,15 @@ const ProjectViewModal = () => {
                           <span className="text-sm font-medium">Figma</span>
                         </Link>
                       )}
-                      {!data?.github_link &&
-                        !data?.website_url &&
-                        !data?.figma_link && (
-                          <p className="text-sm text-gray-500 dark:text-gray-400">
-                            No external links available
-                          </p>
-                        )}
+                      {!data?.github_link && !data?.website_url && !data?.figma_link && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          No external links available
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>
 
-                {/* Project Status & Metadata */}
                 <div className="space-y-4">
                   <div>
                     <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
@@ -258,8 +261,7 @@ const ProjectViewModal = () => {
                       {data?.status === "inprogress"
                         ? "In Progress"
                         : data?.status
-                          ? data.status.charAt(0).toUpperCase() +
-                            data.status.slice(1)
+                          ? data.status.charAt(0).toUpperCase() + data.status.slice(1)
                           : "Pending"}
                     </span>
                   </div>
@@ -307,7 +309,6 @@ const ProjectViewModal = () => {
                 </div>
               </div>
 
-              {/* Tech Stack Section */}
               {data?.tech_stack && data.tech_stack.length > 0 && (
                 <div className="mt-6 border-t pt-6">
                   <h4 className="text-md mb-4 font-medium text-gray-900 dark:text-gray-100">
@@ -338,9 +339,12 @@ const ProjectViewModal = () => {
                 Project Gallery
               </h3>
               <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
-                {(data?.gallery && Array.isArray(data.gallery) && data.gallery.length > 0
-                  ? data.gallery
-                  : [data?.main_image]
+                {(
+                  data?.gallery &&
+                  Array.isArray(data.gallery) &&
+                  data.gallery.length > 0
+                    ? data.gallery
+                    : [data?.main_image]
                 )
                   .filter(Boolean)
                   .map((imageUrl, index) => (
@@ -374,6 +378,12 @@ const ProjectViewModal = () => {
                   <div>
                     <h4 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
                       Team Leader
+                    </h4>
+                    <Skeleton className="h-16 w-64 rounded-lg" />
+                  </div>
+                  <div>
+                    <h4 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      Sub Lead
                     </h4>
                     <Skeleton className="h-16 w-64 rounded-lg" />
                   </div>
@@ -429,6 +439,46 @@ const ProjectViewModal = () => {
                       </p>
                     </div>
                   )}
+
+                  {/* ── CBP-116: Sub Lead display ─────────────────────────────────────
+                      Always renders the section header. Shows avatar + name when assigned,
+                      plain text fallback when no sublead exists for this project.
+                  ──────────────────────────────────────────────────────────────────── */}
+                  <div>
+                    <h4 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      Sub Lead
+                    </h4>
+                    {subLead ? (
+                      <div className="flex items-center gap-4 rounded-lg border border-gray-300 p-4 dark:border-gray-600">
+                        {subLead.image_url ? (
+                          <div className="relative h-12 w-12">
+                            <Image
+                              src={subLead.image_url}
+                              alt={`${subLead.first_name} ${subLead.last_name}`}
+                              fill
+                              className="rounded-full object-cover"
+                              loading="lazy"
+                            />
+                          </div>
+                        ) : (
+                          <DefaultAvatar size={48} />
+                        )}
+                        <div>
+                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                            {subLead.first_name} {subLead.last_name}
+                          </p>
+                          <p className="text-sm text-gray-600 dark:text-gray-400">
+                            {subLead.display_position || "Sub Lead"}
+                          </p>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        No sublead assigned
+                      </p>
+                    )}
+                  </div>
+                  {/* ─────────────────────────────────────────────────────────────── */}
 
                   {/* Team Members */}
                   <div>

--- a/apps/codebility/app/home/projects/actions.ts
+++ b/apps/codebility/app/home/projects/actions.ts
@@ -78,26 +78,13 @@ export async function getUserProjects(): Promise<{
 
     const { data: codevData, error: codevError } = await supabase
       .from("codev")
-      .select("id, email_address")
-      .eq("id", user.id)
+      .select("id")
+      .eq("email_address", user.email)
       .single();
 
     if (codevError || !codevData) {
-      // Fallback: search by email with case-insensitive check
-      const { data: fallbackData } = await supabase
-        .from("codev")
-        .select("id, email_address")
-        .ilike("email_address", user.email || "")
-        .single();
-
-      if (fallbackData) {
-        codevData = fallbackData;
-        codevError = null;
-      }
-    }
-
-    if (codevError || !codevData) {
-      return { error: { message: "User profile not found. Please complete your profile setup." }, data: null };
+      console.error("Error fetching codev_id:", codevError);
+      return { error: { message: "User profile not found" }, data: null };
     }
 
     const userCodevId = codevData.id;
@@ -134,7 +121,8 @@ export async function getUserProjects(): Promise<{
       `,
       )
       .eq("codev_id", userCodevId)
-      .in("role", ["team_leader", "member"]) as { data: ProjectMember[] | null; error: any };
+      // ── CBP-116: added "sublead" so sublead-assigned users see their projects
+      .in("role", ["team_leader", "member", "sublead"]) as { data: ProjectMember[] | null; error: any };
 
     if (projectMembersError) {
       console.error("Error fetching user projects:", projectMembersError);
@@ -444,6 +432,7 @@ export async function updateProject(projectId: string, formData: FormData) {
 
       if (membersError) throw membersError;
 
+      // Preserve joined_at for all existing members (including sublead)
       const joinedAtMap = new Map(
         existingMembers?.map(m => [m.codev_id, m.joined_at]) ?? []
       );
@@ -606,6 +595,66 @@ export const getTeamLead = async (
     return { error, data: null };
   }
 };
+
+// ── CBP-116: getSubLead ───────────────────────────────────────────────────────
+// Mirrors getTeamLead() exactly. Uses maybeSingle() instead of single()
+// because sublead is optional — no row is valid and should not throw.
+export const getSubLead = async (
+  projectId: string,
+): Promise<{
+  error: any;
+  data: SimpleMemberData | null;
+}> => {
+  const supabase = await createClientServerComponent();
+
+  try {
+    const { data, error } = (await supabase
+      .from("project_members")
+      .select(
+        `
+        role,
+        joined_at,
+        codev:codev_id (
+          id,
+          first_name,
+          last_name,
+          email_address,
+          display_position,
+          image_url
+        )
+      `,
+      )
+      .eq("project_id", projectId)
+      .eq("role", "sublead")
+      .maybeSingle()) as { data: DbProjectMemberResponse | null; error: any };
+
+    if (error) {
+      console.error("Error fetching sublead:", error);
+      return { error, data: null };
+    }
+
+    if (!data?.codev) {
+      return { error: null, data: null };
+    }
+
+    const subLead: SimpleMemberData = {
+      id: data.codev.id,
+      first_name: data.codev.first_name,
+      last_name: data.codev.last_name,
+      email_address: data.codev.email_address,
+      display_position: data.codev.display_position,
+      image_url: data.codev.image_url,
+      role: data.role,
+      joined_at: data.joined_at,
+    };
+
+    return { error: null, data: subLead };
+  } catch (error) {
+    console.error("Unexpected error fetching sublead:", error);
+    return { error, data: null };
+  }
+};
+// ─────────────────────────────────────────────────────────────────────────────
 
 /**
  * Fetch project members via two-query approach to avoid RLS/join dropouts.
@@ -960,14 +1009,21 @@ export async function getAllProjects(kanbanBoardId?: string) {
  *
  * ─── PATCH (CBP-95) ──────────────────────────────────────────────────────────
  * Added display_position and email_address to the codev sub-select inside
- * project_members. These fields are required by ProjectEditModal to construct
- * a fallback Codev object when the team leader is absent from getProjectCodevs()
- * results (e.g. filtered out by RLS or internal_status).
+ * project_members for team leader fallback construction in ProjectEditModal.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * ─── PATCH (CBP-116) ─────────────────────────────────────────────────────────
+ * Switched project_members codev data to a two-query approach, mirroring
+ * getMembers(). The PostgREST foreign key join applies RLS on the codev table
+ * which silently drops members whose codev rows are filtered (e.g. Raineer).
+ * Two-query approach: fetch codev_ids from project_members, then fetch codev
+ * records via .in("id", codevIds) — this bypasses the join RLS issue.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 export async function getProjectByID(id: string) {
   const supabase = await createClientServerComponent();
 
+  // Step 1: fetch project row + categories (no codev join here)
   const { data, error } = await supabase
     .from("projects")
     .select(
@@ -977,14 +1033,7 @@ export async function getProjectByID(id: string) {
           id,
           codev_id,
           role,
-          joined_at,
-          codev (
-            first_name,
-            last_name,
-            image_url,
-            display_position,
-            email_address
-          )
+          joined_at
         ),
         categories:project_categories(
           projects_category(
@@ -999,11 +1048,35 @@ export async function getProjectByID(id: string) {
     .single();
 
   if (error) throw error;
+  if (!data) return null;
 
-  const projectWithCategories = data ? {
+  // Step 2: fetch codev records separately to bypass join RLS filtering
+  const codevIds = (data.project_members ?? []).map((pm: any) => pm.codev_id);
+
+  let codevMap: Map<string, any> = new Map();
+
+  if (codevIds.length > 0) {
+    const { data: codevs, error: codevError } = await supabase
+      .from("codev")
+      .select("id, first_name, last_name, image_url, display_position, email_address")
+      .in("id", codevIds);
+
+    if (codevError) {
+      console.error("Error fetching codev records for project members:", codevError);
+    } else {
+      codevs?.forEach((c: any) => codevMap.set(c.id, c));
+    }
+  }
+
+  // Step 3: merge codev data back into project_members
+  const projectMembersWithCodev = (data.project_members ?? []).map((pm: any) => ({
+    ...pm,
+    codev: codevMap.get(pm.codev_id) ?? null,
+  }));
+
+  return {
     ...data,
+    project_members: projectMembersWithCodev,
     categories: data.categories?.map((cat: any) => cat.projects_category).filter(Boolean) || [],
-  } : null;
-
-  return projectWithCategories;
+  };
 }

--- a/apps/codebility/tree_output.txt
+++ b/apps/codebility/tree_output.txt
@@ -1,0 +1,1248 @@
+.
+├── __tests__
+│   ├── components
+│   │   └── leaderboard
+│   │       └── LeaderboardTable.test.tsx
+│   └── hooks
+│       └── useLeaderboard.test.ts
+├── app
+│   ├── (marketing)
+│   │   ├── _components
+│   │   │   ├── landing
+│   │   │   │   ├── AnimatedAdminsSection.tsx
+│   │   │   │   ├── FloatingParticles.tsx
+│   │   │   │   ├── ForceScrollTop.tsx
+│   │   │   │   ├── LandingAdminCard.tsx
+│   │   │   │   ├── LandingAdmins.tsx
+│   │   │   │   ├── LandingBlueBg.tsx
+│   │   │   │   ├── LandingDiamond.tsx
+│   │   │   │   ├── LandingFeatures.tsx
+│   │   │   │   ├── LandingFeaturesCard.tsx
+│   │   │   │   ├── LandingGridBg.tsx
+│   │   │   │   ├── LandingHero.tsx
+│   │   │   │   ├── LandingHeroBg.tsx
+│   │   │   │   ├── LandingHeroCard.tsx
+│   │   │   │   ├── LandingIntern-CodevCard.tsx
+│   │   │   │   ├── LandingIntern-CodevPagination.tsx
+│   │   │   │   ├── LandingInternSection.tsx
+│   │   │   │   ├── LandingMarketing.tsx
+│   │   │   │   ├── LandingMarketingCard.tsx
+│   │   │   │   ├── LandingMarquee.tsx
+│   │   │   │   ├── LandingMovingText.tsx
+│   │   │   │   ├── LandingParallax.tsx
+│   │   │   │   ├── LandingPartners.tsx
+│   │   │   │   ├── LandingPurpleBg.tsx
+│   │   │   │   ├── LandingScrollToHash.tsx
+│   │   │   │   ├── LandingServices.tsx
+│   │   │   │   ├── LandingServicesCard.tsx
+│   │   │   │   ├── LandingWhyChoose-us.tsx
+│   │   │   │   ├── LandingWhyChoose.tsx
+│   │   │   │   └── LandingWorkWithUs.tsx
+│   │   │   ├── marketing_modals
+│   │   │   │   ├── MarketingFaqsModal.tsx
+│   │   │   │   ├── MarketingPrivacyPolicyModal.tsx
+│   │   │   │   └── MarketingTermsAndConditionModal.tsx
+│   │   │   ├── testimonial
+│   │   │   │   └── Testimonials.tsx
+│   │   │   ├── MarketingCalendly.tsx
+│   │   │   ├── MarketingContainer.tsx
+│   │   │   ├── MarketingFooter.tsx
+│   │   │   ├── MarketingNavigation.tsx
+│   │   │   ├── MarketingSection.tsx
+│   │   │   └── MarketingSidenavMenu.tsx
+│   │   ├── _lib
+│   │   │   └── util.ts
+│   │   ├── _shared
+│   │   │   ├── CodevsAbout.tsx
+│   │   │   ├── CodevsAboutCard.tsx
+│   │   │   ├── CodevsCarousel.tsx
+│   │   │   ├── CodevsCta.tsx
+│   │   │   ├── CodevsEmblaCarouselArrowButtons.tsx
+│   │   │   ├── CodevsFeaturedCard.tsx
+│   │   │   ├── CodevsFeaturedCection.tsx
+│   │   │   ├── CodevsFeaturedFooter.tsx
+│   │   │   ├── CodevsFeaturedProjectCard.tsx
+│   │   │   ├── CodevsFeaturedProjects.tsx
+│   │   │   └── CodevsSection.tsx
+│   │   ├── ai-integration
+│   │   │   ├── _components
+│   │   │   │   ├── AiIntegration-development-process-react-flow.tsx
+│   │   │   │   ├── AiIntegrationDevelopmentProcess.tsx
+│   │   │   │   ├── AiIntegrationEdgeTypes.tsx
+│   │   │   │   ├── AiIntegrationGradientBgWhite.tsx
+│   │   │   │   ├── AiIntegrationHeroBg.tsx
+│   │   │   │   ├── AiIntegrationLatestTech.tsx
+│   │   │   │   ├── AiIntegrationMobileAppServices.tsx
+│   │   │   │   ├── AiIntegrationNextStep.tsx
+│   │   │   │   ├── AiIntegrationNodeTypes.tsx
+│   │   │   │   ├── AiIntegrationPartner.tsx
+│   │   │   │   ├── AiIntegrationPartnerCard.tsx
+│   │   │   │   ├── AiIntegrationPartnerReactFlow.tsx
+│   │   │   │   ├── AiIntegrationProcessCard.tsx
+│   │   │   │   ├── AiIntegrationSolutions.tsx
+│   │   │   │   ├── AiIntegrationUnparallelCard.tsx
+│   │   │   │   └── AiIntegrationUnparallelDigitalSuccess.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── dummy-data.tsx
+│   │   │   ├── _styles
+│   │   │   │   └── index.css
+│   │   │   ├── _types
+│   │   │   │   └── index.ts
+│   │   │   └── page.tsx
+│   │   ├── bookacall
+│   │   │   ├── _components
+│   │   │   │   └── BookACallCalendlyWidgetContainer.tsx
+│   │   │   └── page.tsx
+│   │   ├── careers
+│   │   │   ├── _components
+│   │   │   │   ├── CareerGrowthPath.tsx
+│   │   │   │   ├── CodevLandingHero.tsx
+│   │   │   │   ├── CodevsFeaturedProjects.tsx
+│   │   │   │   ├── CodevsHero.tsx
+│   │   │   │   ├── CodevsMissionVision.tsx
+│   │   │   │   ├── CodevsNavbar.tsx
+│   │   │   │   ├── CodevsOrbitingCircles.tsx
+│   │   │   │   ├── CodevsOrbitingCirclesBg.tsx
+│   │   │   │   ├── CodevsProject.tsx
+│   │   │   │   ├── CodevsRoadmap.tsx
+│   │   │   │   ├── CodevsRoadmapCard.tsx
+│   │   │   │   ├── CodevsServiceCard.tsx
+│   │   │   │   ├── CodevsServices.tsx
+│   │   │   │   ├── CodevsWhyChoose.tsx
+│   │   │   │   ├── CodevsWhyChooseItem.tsx
+│   │   │   │   ├── CompanyValues.tsx
+│   │   │   │   ├── JobApplicationModal.tsx
+│   │   │   │   ├── JobListings.tsx
+│   │   │   │   ├── TechStack.tsx
+│   │   │   │   └── WorkplaceCulture.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── dummy-data.ts
+│   │   │   ├── _types
+│   │   │   │   └── job-listings.ts
+│   │   │   └── page.tsx
+│   │   ├── codevs
+│   │   │   ├── _components
+│   │   │   │   ├── CodevsFeaturedProjects.tsx
+│   │   │   │   ├── CodevsHero.tsx
+│   │   │   │   ├── CodevsMissionVision.tsx
+│   │   │   │   ├── CodevsNavbar.tsx
+│   │   │   │   ├── CodevsOrbitingCircles.tsx
+│   │   │   │   ├── CodevsOrbitingCirclesBg.tsx
+│   │   │   │   ├── CodevsProfiles.tsx
+│   │   │   │   ├── CodevsProfilesContainer.tsx
+│   │   │   │   ├── CodevsProject.tsx
+│   │   │   │   ├── CodevsRoadmap.tsx
+│   │   │   │   ├── CodevsRoadmapCard.tsx
+│   │   │   │   ├── CodevsRoadmapStatic.tsx
+│   │   │   │   ├── CodevsServiceCard.tsx
+│   │   │   │   ├── CodevsServices.tsx
+│   │   │   │   ├── CodevsWhyChoose.tsx
+│   │   │   │   ├── CodevsWhyChooseItem.tsx
+│   │   │   │   └── HiringProcess.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── dummy-data.ts
+│   │   │   └── page.tsx
+│   │   ├── contact
+│   │   │   ├── _components
+│   │   │   │   ├── ContactAppointment.tsx
+│   │   │   │   ├── ContactInquiryInform.tsx
+│   │   │   │   └── ContactShortSurvey.tsx
+│   │   │   └── page.tsx
+│   │   ├── hire-a-codev
+│   │   │   ├── _components
+│   │   │   │   ├── CodevsFeaturedProjects.tsx
+│   │   │   │   ├── CodevsHero.tsx
+│   │   │   │   ├── CodevsMissionVision.tsx
+│   │   │   │   ├── CodevsNavbar.tsx
+│   │   │   │   ├── CodevsOrbitingCircles.tsx
+│   │   │   │   ├── CodevsOrbitingCirclesBg.tsx
+│   │   │   │   ├── CodevsProject.tsx
+│   │   │   │   ├── CodevsRoadmap.tsx
+│   │   │   │   ├── CodevsRoadmapCard.tsx
+│   │   │   │   ├── CodevsServiceCard.tsx
+│   │   │   │   ├── CodevsServices.tsx
+│   │   │   │   ├── CodevsWhyChoose.tsx
+│   │   │   │   ├── CodevsWhyChooseItem.tsx
+│   │   │   │   └── HiringProcess.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── dummy-data.ts
+│   │   │   └── page.tsx
+│   │   ├── privacy-policy
+│   │   │   └── page.tsx
+│   │   ├── profiles
+│   │   │   ├── [id]
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── ProfileCloseButton.tsx
+│   │   │   │   │   ├── ProfileContent.tsx
+│   │   │   │   │   ├── ProjectList.tsx
+│   │   │   │   │   └── StarRating.tsx
+│   │   │   │   ├── _services
+│   │   │   │   │   └── query.ts
+│   │   │   │   └── page.tsx
+│   │   │   ├── _components
+│   │   │   │   ├── CodevCard.tsx
+│   │   │   │   ├── CodevContainer.tsx
+│   │   │   │   ├── CodevHireCodevButton.tsx
+│   │   │   │   ├── CodevHireCodevModal.tsx
+│   │   │   │   ├── CodevList.tsx
+│   │   │   │   └── CodevListFilter.tsx
+│   │   │   ├── _service
+│   │   │   │   ├── template
+│   │   │   │   │   └── hire-codev-template.ts
+│   │   │   │   ├── actions.ts
+│   │   │   │   └── emailAction.ts
+│   │   │   └── page.tsx
+│   │   ├── services
+│   │   │   ├── _components
+│   │   │   │   ├── layout
+│   │   │   │   │   ├── ServiceDetailModal.tsx
+│   │   │   │   │   ├── ServiceDetailView.tsx
+│   │   │   │   │   ├── ServicesGrid.tsx
+│   │   │   │   │   ├── ServicesHero.tsx
+│   │   │   │   │   ├── ServicesPageContent.tsx
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── tabs
+│   │   │   │   │   ├── ServicesTab.tsx
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── ui
+│   │   │   │   │   ├── ServicesServiceCard.tsx
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── visuals
+│   │   │   │   │   ├── ClientTechyBackground.tsx
+│   │   │   │   │   ├── TechyBackground.tsx
+│   │   │   │   │   └── index.ts
+│   │   │   │   └── index.ts
+│   │   │   ├── _context
+│   │   │   │   ├── ServiceContext.tsx
+│   │   │   │   └── index.ts
+│   │   │   ├── _lib
+│   │   │   │   └── dummy-data.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── layout.tsx
+│   │   └── page.tsx
+│   ├── api
+│   │   ├── all-active-interns-codev
+│   │   │   └── route.ts
+│   │   ├── all-active-interns-codev-prioritized
+│   │   │   └── route.ts
+│   │   ├── attendance
+│   │   │   └── route.ts
+│   │   ├── codev
+│   │   │   └── [codevId]
+│   │   │       └── points
+│   │   │           └── route.ts
+│   │   ├── cron
+│   │   │   └── meeting-reminders
+│   │   │       └── route.ts
+│   │   ├── delete-auth-user
+│   │   │   └── route.ts
+│   │   ├── email-verification
+│   │   │   └── route.ts
+│   │   ├── job-applications
+│   │   │   └── route.ts
+│   │   ├── job-listings
+│   │   │   └── route.ts
+│   │   ├── nda-document
+│   │   │   └── [id]
+│   │   │       └── route.ts
+│   │   ├── profile-points
+│   │   │   └── [codevId]
+│   │   │       └── route.ts
+│   │   ├── project-leaderboard
+│   │   │   └── route.ts
+│   │   ├── projects
+│   │   │   └── today
+│   │   │       └── route.ts
+│   │   ├── send-email
+│   │   │   └── route.ts
+│   │   ├── soft-skills-leaderboard
+│   │   │   └── route.ts
+│   │   ├── team
+│   │   │   └── route.ts
+│   │   └── technical-leaderboard
+│   │       └── route.ts
+│   ├── applicant
+│   │   ├── account-settings
+│   │   │   └── page.tsx
+│   │   ├── onboarding
+│   │   │   ├── _components
+│   │   │   │   ├── Commitment.tsx
+│   │   │   │   ├── OnboardingClient.tsx
+│   │   │   │   ├── OnboardingStepper.tsx
+│   │   │   │   ├── Quiz.tsx
+│   │   │   │   ├── VideoPlayer.tsx
+│   │   │   │   └── quizData.ts
+│   │   │   ├── _service
+│   │   │   │   ├── action.ts
+│   │   │   │   └── type.ts
+│   │   │   ├── README.md
+│   │   │   └── page.tsx
+│   │   ├── profile
+│   │   │   ├── layout.tsx
+│   │   │   └── page.tsx
+│   │   ├── waiting
+│   │   │   ├── _components
+│   │   │   │   ├── Stepper.tsx
+│   │   │   │   ├── applicantFetchComp.tsx
+│   │   │   │   ├── applicantStep1.tsx
+│   │   │   │   ├── applicantStep2.tsx
+│   │   │   │   ├── applicantStep3.tsx
+│   │   │   │   ├── applicantStep4.tsx
+│   │   │   │   ├── applicationSteps.tsx
+│   │   │   │   ├── testCountDown.tsx
+│   │   │   │   ├── testInstruction.tsx
+│   │   │   │   └── testQAInstruction.tsx
+│   │   │   ├── _service
+│   │   │   │   ├── action.ts
+│   │   │   │   ├── type.ts
+│   │   │   │   └── util.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   └── layout.tsx
+│   ├── auth
+│   │   ├── callback
+│   │   │   └── route.ts
+│   │   ├── declined
+│   │   │   ├── _components
+│   │   │   │   ├── DeclineComponent.tsx
+│   │   │   │   ├── DeclinedButtons.tsx
+│   │   │   │   └── DeclinedCountdown.tsx
+│   │   │   ├── _service
+│   │   │   │   ├── actions.ts
+│   │   │   │   └── util.ts
+│   │   │   └── page.tsx
+│   │   ├── onboarding
+│   │   │   ├── _components
+│   │   │   │   ├── Expect
+│   │   │   │   │   └── ExpectSection.tsx
+│   │   │   │   ├── ExpectFromUs
+│   │   │   │   │   └── ExpectFromUsSection.tsx
+│   │   │   │   ├── HeroWithAboutEffect
+│   │   │   │   │   ├── Slides
+│   │   │   │   │   │   ├── AboutUs.tsx
+│   │   │   │   │   │   ├── Launchpad.tsx
+│   │   │   │   │   │   ├── MissionVisionSlide.tsx
+│   │   │   │   │   │   └── WhyChooseUsSlide.tsx
+│   │   │   │   │   ├── hooks
+│   │   │   │   │   │   └── useHeroAnimations.ts
+│   │   │   │   │   ├── AboutSlides.tsx
+│   │   │   │   │   ├── BubbleBackground.tsx
+│   │   │   │   │   ├── FloatingCodeTags.tsx
+│   │   │   │   │   ├── HeroSection.tsx
+│   │   │   │   │   ├── LottieBackground.tsx
+│   │   │   │   │   ├── StickyLogo.tsx
+│   │   │   │   │   └── index.tsx
+│   │   │   │   ├── HouseRules
+│   │   │   │   │   └── HouseRulesSection.tsx
+│   │   │   │   ├── IsAndIsnt
+│   │   │   │   │   └── IsAndIsntSection.tsx
+│   │   │   │   ├── IsNot
+│   │   │   │   │   └── IsNotSection.tsx
+│   │   │   │   ├── Mindset
+│   │   │   │   │   └── MindsetSection.tsx
+│   │   │   │   ├── Partners
+│   │   │   │   │   └── PartnersSection.tsx
+│   │   │   │   ├── RoadMap
+│   │   │   │   │   ├── AnimatedRoadmapSvg.tsx
+│   │   │   │   │   ├── AnimatedRoadmapWrapper.tsx
+│   │   │   │   │   ├── IsRoadMap.tsx
+│   │   │   │   │   └── RoadMapIntro.tsx
+│   │   │   │   ├── SoftwareDevelopment
+│   │   │   │   │   ├── SoftwareDevelopmentBackground.tsx
+│   │   │   │   │   └── SoftwareDevelopmentSection.tsx
+│   │   │   │   ├── Team
+│   │   │   │   │   ├── TeamSection.tsx
+│   │   │   │   │   └── actions.ts
+│   │   │   │   └── Wellcome
+│   │   │   │       └── WellcomeSection.tsx
+│   │   │   ├── hooks
+│   │   │   │   └── useOnboardingAnimations.ts
+│   │   │   ├── ExpectFromUsWrapper.tsx
+│   │   │   ├── ExpectSectionWrapper.tsx
+│   │   │   ├── HouseRulesSectionWrapper.tsx
+│   │   │   ├── IsAndIsntSectionWrapper.tsx
+│   │   │   ├── IsNotSectionWrapper.tsx
+│   │   │   ├── MindsetSectionWrapper.tsx
+│   │   │   ├── OnboardingClientWrapper.tsx
+│   │   │   ├── OnboardingStepper.tsx
+│   │   │   ├── PartnersSectionWrapper.tsx
+│   │   │   ├── RoadMapSectionWrapper.tsx
+│   │   │   ├── SoftwareSectionWrapper.tsx
+│   │   │   ├── TeamSectionWrapper.tsx
+│   │   │   ├── WellcomeSectionWrapper.tsx
+│   │   │   └── page.tsx
+│   │   ├── password-reset
+│   │   │   ├── _components
+│   │   │   │   └── PasswordResetForm.tsx
+│   │   │   ├── action.ts
+│   │   │   └── page.tsx
+│   │   ├── sign-in
+│   │   │   ├── _components
+│   │   │   │   ├── SignInForm.tsx
+│   │   │   │   └── SignInInput.tsx
+│   │   │   └── page.tsx
+│   │   ├── sign-up
+│   │   │   ├── _components
+│   │   │   │   ├── ImageUpload.tsx
+│   │   │   │   ├── PositionMultiselectField.tsx
+│   │   │   │   ├── PositionSelect.tsx
+│   │   │   │   ├── SignUpForm.tsx
+│   │   │   │   ├── SignUpFormWrapper.tsx
+│   │   │   │   ├── SignUpInput.tsx
+│   │   │   │   ├── TechstackMultiselectForm.tsx
+│   │   │   │   └── form-steps.ts
+│   │   │   └── page.tsx
+│   │   ├── verify
+│   │   │   └── page.tsx
+│   │   ├── waiting
+│   │   │   ├── layout.tsx
+│   │   │   └── page.tsx
+│   │   └── actions.ts
+│   ├── emails
+│   │   └── nda-template.tsx
+│   ├── home
+│   │   ├── (dashboard)
+│   │   │   ├── _components
+│   │   │   │   ├── DashboardCalendar.tsx
+│   │   │   │   ├── DashboardCareerOpportunities.tsx
+│   │   │   │   ├── DashboardCertificate.tsx
+│   │   │   │   ├── DashboardCertificateIcons.tsx
+│   │   │   │   ├── DashboardCompleteProfile.tsx
+│   │   │   │   ├── DashboardCurrentProject.tsx
+│   │   │   │   ├── DashboardCurrentProjectButton.tsx
+│   │   │   │   ├── DashboardCurrentProjectModal.tsx
+│   │   │   │   ├── DashboardDownloadCertificate.tsx
+│   │   │   │   ├── DashboardProfile.tsx
+│   │   │   │   ├── DashboardProgressRoadmap.tsx
+│   │   │   │   ├── DashboardRoadmap.tsx
+│   │   │   │   ├── DashboardRoadmapStyleRoot.tsx
+│   │   │   │   ├── DashboardRoleRoadmap.tsx
+│   │   │   │   ├── DashboardStatus.tsx
+│   │   │   │   ├── DashboardTimeTracker.tsx
+│   │   │   │   ├── DashboardTimeTrackerSchedule.tsx
+│   │   │   │   ├── DashboardTimeTrackerTimer.tsx
+│   │   │   │   ├── DashboardTokenPoints.tsx
+│   │   │   │   ├── DashboardWeeklyTop.tsx
+│   │   │   │   └── PhaseDetailsModal.tsx
+│   │   │   ├── _lib
+│   │   │   │   ├── theme.ts
+│   │   │   │   └── util.ts
+│   │   │   └── actions.ts
+│   │   ├── _components
+│   │   │   ├── ConditionalMainWrapper.tsx
+│   │   │   ├── DashboardClient.tsx
+│   │   │   ├── DynamicMainContent.tsx
+│   │   │   ├── HomeToastNotification.tsx
+│   │   │   ├── LeftSidebar.tsx
+│   │   │   ├── LeftSidebarClient.tsx
+│   │   │   ├── LeftSidebarServer.tsx
+│   │   │   ├── MobileNav.tsx
+│   │   │   ├── Navbar.tsx
+│   │   │   ├── NavbarContent.tsx
+│   │   │   ├── NavigationOptimizer.tsx
+│   │   │   ├── NewsBanner.tsx
+│   │   │   ├── OptimizedLayout.tsx
+│   │   │   ├── PageContainer.tsx
+│   │   │   ├── PageLoadingAnimation.tsx
+│   │   │   ├── PageLoadingVariants.tsx
+│   │   │   ├── PageTransitionSettings.tsx
+│   │   │   ├── PageTransitionWrapper.tsx
+│   │   │   ├── SurveyWidget.tsx
+│   │   │   └── UserProvider.tsx
+│   │   ├── _hooks
+│   │   │   ├── supabase
+│   │   │   │   └── use-fetch-enum.ts
+│   │   │   └── use-user.ts
+│   │   ├── _services
+│   │   │   └── actions.ts
+│   │   ├── account-settings
+│   │   │   ├── _components
+│   │   │   │   ├── AccountSettings2FA.tsx
+│   │   │   │   ├── AccountSettingsBackDrop.tsx
+│   │   │   │   ├── AccountSettingsChangePassword.tsx
+│   │   │   │   ├── AccountSettingsDelete.tsx
+│   │   │   │   ├── AccountSettingsDialog.tsx
+│   │   │   │   ├── AccountSettingsHeader.tsx
+│   │   │   │   └── AccountSettingsUsername.tsx
+│   │   │   ├── action.ts
+│   │   │   └── page.tsx
+│   │   ├── admin-controls
+│   │   │   ├── client-tracker
+│   │   │   │   ├── _components
+│   │   │   │   │   └── ClientTrackerContent.tsx
+│   │   │   │   ├── actions.ts
+│   │   │   │   ├── page.tsx
+│   │   │   │   └── utils.ts
+│   │   │   ├── ticket-support
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── TicketDataTable.tsx
+│   │   │   │   │   ├── TicketManagementView.tsx
+│   │   │   │   │   └── TicketPreviewSidebar.tsx
+│   │   │   │   ├── actions.ts
+│   │   │   │   ├── page.tsx
+│   │   │   │   └── types.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── admin-dashboard
+│   │   │   ├── _components
+│   │   │   │   ├── AdminDashboardApplicantStatusPie.tsx
+│   │   │   │   ├── AdminDashboardMonthlyApplicantsLineChart.tsx
+│   │   │   │   ├── AdminDashboardProjectsPie.tsx
+│   │   │   │   ├── AdminDashboardStatsCard.tsx
+│   │   │   │   ├── AdminDashboardTotalActiveIntern.tsx
+│   │   │   │   ├── AdminDashboardTotalAdmin.tsx
+│   │   │   │   ├── AdminDashboardTotalCodev.tsx
+│   │   │   │   ├── AdminDashboardTotalInactiveIntern.tsx
+│   │   │   │   ├── AdminDashboardTotalMentor.tsx
+│   │   │   │   └── AdminDashboardTotalProject.tsx
+│   │   │   ├── layout.tsx
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── announcements
+│   │   │   ├── AnnouncementButton.tsx
+│   │   │   ├── AnnouncementContent.tsx
+│   │   │   ├── AnnouncementEditor.tsx
+│   │   │   ├── AnnouncementModal.tsx
+│   │   │   ├── AnnouncementRichTextEditor.tsx
+│   │   │   ├── AnnouncementRichTextEditorMenuBar.tsx
+│   │   │   ├── AnnouncementTab.tsx
+│   │   │   ├── data.ts
+│   │   │   ├── types.ts
+│   │   │   └── utils.ts
+│   │   ├── applicants
+│   │   │   ├── _components
+│   │   │   │   ├── _table
+│   │   │   │   │   ├── ApplicantConfirmationDialog.tsx
+│   │   │   │   │   ├── applicantActionButton.original.tsx
+│   │   │   │   │   ├── applicantActionButton.tsx
+│   │   │   │   │   ├── applicantActionConfig.ts
+│   │   │   │   │   ├── applicantActionTypes.ts
+│   │   │   │   │   ├── applicantColumns.tsx
+│   │   │   │   │   ├── applicantDataTable.tsx
+│   │   │   │   │   ├── applicantMobileTable.tsx
+│   │   │   │   │   ├── applicantProfileColSec.tsx
+│   │   │   │   │   ├── applicantRowActionButton.tsx
+│   │   │   │   │   └── useApplicantActions.ts
+│   │   │   │   ├── ApplicantClientWrapper.tsx
+│   │   │   │   ├── ApplicantDataWrapper.tsx
+│   │   │   │   ├── ApplicantProfileModal.tsx
+│   │   │   │   ├── applicantEmailAction.tsx
+│   │   │   │   ├── applicantFetchComp.tsx
+│   │   │   │   ├── applicantFilters.tsx
+│   │   │   │   ├── applicantFiltersBadge.tsx
+│   │   │   │   ├── applicantHeaders.tsx
+│   │   │   │   ├── applicantLists.tsx
+│   │   │   │   ├── applicantReapplyTime.tsx
+│   │   │   │   ├── applicantSorters.tsx
+│   │   │   │   ├── applicantTechStack.tsx
+│   │   │   │   └── applicantTestTimeRemaining.tsx
+│   │   │   ├── _service
+│   │   │   │   ├── email
+│   │   │   │   │   ├── actions
+│   │   │   │   │   │   ├── accepted.ts
+│   │   │   │   │   │   ├── deny.ts
+│   │   │   │   │   │   ├── failedTest.ts
+│   │   │   │   │   │   ├── onboardingReminder.ts
+│   │   │   │   │   │   ├── passedTest.ts
+│   │   │   │   │   │   └── testReminder.ts
+│   │   │   │   │   ├── templates
+│   │   │   │   │   │   ├── accepted.ts
+│   │   │   │   │   │   ├── deny.ts
+│   │   │   │   │   │   ├── failedTest.ts
+│   │   │   │   │   │   ├── onboardingReminder.ts
+│   │   │   │   │   │   ├── passedTest.ts
+│   │   │   │   │   │   └── testReminder.ts
+│   │   │   │   │   ├── config.ts
+│   │   │   │   │   ├── index.ts
+│   │   │   │   │   └── types.ts
+│   │   │   │   ├── action.ts
+│   │   │   │   ├── emailAction.ts
+│   │   │   │   ├── query.ts
+│   │   │   │   └── types.ts
+│   │   │   ├── error.tsx
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── certificate-preview
+│   │   │   └── page.tsx
+│   │   ├── clients
+│   │   │   ├── _components
+│   │   │   │   ├── ClientAddModal.tsx
+│   │   │   │   ├── ClientEditModal.tsx
+│   │   │   │   ├── ClientsButton.tsx
+│   │   │   │   └── ClientsCard.tsx
+│   │   │   ├── _lib
+│   │   │   │   ├── schema.ts
+│   │   │   │   └── utils.ts
+│   │   │   ├── action.ts
+│   │   │   ├── error.tsx
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── feeds
+│   │   │   ├── _components
+│   │   │   │   ├── CreatePostForm.tsx
+│   │   │   │   ├── DeleteDialog.tsx
+│   │   │   │   ├── EditPostForm.tsx
+│   │   │   │   ├── Feed.tsx
+│   │   │   │   ├── FirstPostPrompt.tsx
+│   │   │   │   ├── MarkdownEditor.tsx
+│   │   │   │   ├── PostCard.tsx
+│   │   │   │   ├── PostCardSkeleton.tsx
+│   │   │   │   ├── PostCommentCount.tsx
+│   │   │   │   ├── PostTags.tsx
+│   │   │   │   ├── PostUpvote.tsx
+│   │   │   │   ├── PostView.tsx
+│   │   │   │   ├── PostViewCommentItem.tsx
+│   │   │   │   ├── PostViewCommentList.tsx
+│   │   │   │   ├── PostViewCreateComment.tsx
+│   │   │   │   ├── SocialPointsCard.tsx
+│   │   │   │   ├── SortMenu.tsx
+│   │   │   │   ├── TagSelector.tsx
+│   │   │   │   └── ThumbnailUpload.tsx
+│   │   │   ├── _constants
+│   │   │   │   ├── index.ts
+│   │   │   │   └── system-post.ts
+│   │   │   ├── _services
+│   │   │   │   ├── action.ts
+│   │   │   │   ├── notification-service.ts
+│   │   │   │   ├── query.ts
+│   │   │   │   ├── types.ts
+│   │   │   │   └── validation.ts
+│   │   │   ├── IMPROVEMENTS.md
+│   │   │   └── page.tsx
+│   │   ├── hire
+│   │   │   ├── _components
+│   │   │   │   ├── ApplicationDetailsModal.tsx
+│   │   │   │   ├── CreateJobForm.tsx
+│   │   │   │   ├── EditJobModal.tsx
+│   │   │   │   ├── HirePageClient.tsx
+│   │   │   │   └── JobListingsTable.tsx
+│   │   │   ├── applications
+│   │   │   │   └── [jobId]
+│   │   │   │       ├── client-page.tsx
+│   │   │   │       └── page.tsx
+│   │   │   ├── actions.ts
+│   │   │   └── page.tsx
+│   │   ├── in-house
+│   │   │   ├── _components
+│   │   │   │   ├── cards
+│   │   │   │   │   ├── CodevCard.tsx
+│   │   │   │   │   ├── EditableCard.tsx
+│   │   │   │   │   └── InHouseCards.tsx
+│   │   │   │   ├── shared
+│   │   │   │   │   ├── DeleteDialog.tsx
+│   │   │   │   │   ├── ProjectSelect.tsx
+│   │   │   │   │   └── StatusBadge.tsx
+│   │   │   │   ├── skeletons
+│   │   │   │   │   ├── InHouseHeaderSkeleton.tsx
+│   │   │   │   │   ├── InHouseLoadingSkeleton.tsx
+│   │   │   │   │   ├── InHouseTableSkeleton.tsx
+│   │   │   │   │   └── index.ts
+│   │   │   │   ├── table
+│   │   │   │   │   ├── EditableRow.tsx
+│   │   │   │   │   ├── InHouseMobileTable.tsx
+│   │   │   │   │   ├── InHousePreviewSidebar.tsx
+│   │   │   │   │   ├── InHouseTable.tsx
+│   │   │   │   │   ├── MobileEditableForm.tsx
+│   │   │   │   │   ├── TableActions.tsx
+│   │   │   │   │   ├── columns.ts
+│   │   │   │   │   └── table-filters.tsx
+│   │   │   │   ├── EditDialog.tsx
+│   │   │   │   └── InHouseView.tsx
+│   │   │   ├── _hooks
+│   │   │   │   └── use-codev-form.ts
+│   │   │   ├── _lib
+│   │   │   │   └── utils.ts
+│   │   │   ├── _types
+│   │   │   │   └── in-house.ts
+│   │   │   ├── actions.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── interns
+│   │   │   ├── _components
+│   │   │   │   ├── AnimatedCodevCardSkeleton.tsx
+│   │   │   │   ├── CodevCard.tsx
+│   │   │   │   ├── CodevCardSkeleton.tsx
+│   │   │   │   ├── CodevContainer.tsx
+│   │   │   │   ├── CodevContainerSkeleton.tsx
+│   │   │   │   ├── CodevList.tsx
+│   │   │   │   ├── CodevListSkeleton.tsx
+│   │   │   │   ├── CodevSearchbar.tsx
+│   │   │   │   ├── FilterCodevs.tsx
+│   │   │   │   ├── InternalProjects.tsx
+│   │   │   │   ├── ProfileModal.tsx
+│   │   │   │   ├── SkillPoints.tsx
+│   │   │   │   └── TechStacks.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── codevpriority.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── kanban
+│   │   │   ├── [projectId]
+│   │   │   │   ├── [id]
+│   │   │   │   │   ├── _components
+│   │   │   │   │   │   ├── kanban_modals
+│   │   │   │   │   │   │   ├── KanbanAddMembersButton.tsx
+│   │   │   │   │   │   │   ├── KanbanAddMembersModal.tsx
+│   │   │   │   │   │   │   ├── KanbanAddModalMembers.tsx
+│   │   │   │   │   │   │   ├── KanbanColumnAddButton.tsx
+│   │   │   │   │   │   │   ├── KanbanColumnAddModal.tsx
+│   │   │   │   │   │   │   ├── KanbanRichTextDisplay.tsx
+│   │   │   │   │   │   │   ├── KanbanRichTextEditor.tsx
+│   │   │   │   │   │   │   ├── KanbanRichTextEditorMenuBar.tsx
+│   │   │   │   │   │   │   ├── KanbanTaskAddModal.tsx
+│   │   │   │   │   │   │   ├── KanbanTaskViewEditModal.tsx
+│   │   │   │   │   │   │   └── MobileTaskMoveModal.tsx
+│   │   │   │   │   │   ├── tasks
+│   │   │   │   │   │   │   ├── _components
+│   │   │   │   │   │   │   │   └── TaskComments.tsx
+│   │   │   │   │   │   │   ├── TaskAddModal.tsx
+│   │   │   │   │   │   │   ├── TaskDeleteModal.tsx
+│   │   │   │   │   │   │   ├── TaskEditModal.tsx
+│   │   │   │   │   │   │   └── TaskViewModal.tsx
+│   │   │   │   │   │   ├── ArchiveColumn.tsx
+│   │   │   │   │   │   ├── ArchiveTask.tsx
+│   │   │   │   │   │   ├── DifficultyPointsTooltip.tsx
+│   │   │   │   │   │   ├── KanbanBoard.tsx
+│   │   │   │   │   │   ├── KanbanBoardColumnContainer.tsx
+│   │   │   │   │   │   ├── KanbanColumn.tsx
+│   │   │   │   │   │   ├── KanbanTask.tsx
+│   │   │   │   │   │   ├── KanbanTaskOverlayWrapper.tsx
+│   │   │   │   │   │   └── UserTaskFilter.tsx
+│   │   │   │   │   ├── _services
+│   │   │   │   │   │   └── query.ts
+│   │   │   │   │   ├── actions.ts
+│   │   │   │   │   ├── loading.tsx
+│   │   │   │   │   └── page.tsx
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── AddSprintButton.tsx
+│   │   │   │   │   └── SprintAddModal.tsx
+│   │   │   │   ├── _services
+│   │   │   │   │   └── query.ts
+│   │   │   │   ├── actions.ts
+│   │   │   │   └── page.tsx
+│   │   │   ├── _components
+│   │   │   │   ├── BoardAddModal.tsx
+│   │   │   │   ├── DeleteDialog.tsx
+│   │   │   │   ├── EditSprintForm.tsx
+│   │   │   │   ├── KanbanBoardAddModal.tsx
+│   │   │   │   ├── KanbanBoardsSearch.tsx
+│   │   │   │   └── TableActions.tsx
+│   │   │   ├── ticket
+│   │   │   │   └── [ticketCode]
+│   │   │   │       ├── actions.ts
+│   │   │   │       └── page.tsx
+│   │   │   ├── actions.ts
+│   │   │   ├── layout.tsx
+│   │   │   └── page.tsx
+│   │   ├── my-team
+│   │   │   ├── [projectId]
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── AttendanceGrid.tsx
+│   │   │   │   │   ├── AttendanceSync.tsx
+│   │   │   │   │   ├── AttendanceTracker.tsx
+│   │   │   │   │   ├── AttendanceWarningBanner.tsx
+│   │   │   │   │   ├── ChecklistStatusBanner.tsx
+│   │   │   │   │   ├── CompactMemberGrid.tsx
+│   │   │   │   │   ├── MeetingBasedAttendance.tsx
+│   │   │   │   │   ├── MeetingScheduler.tsx
+│   │   │   │   │   ├── ScheduleMeetingModal.tsx
+│   │   │   │   │   ├── SyncAllAttendance.tsx
+│   │   │   │   │   └── TeamDetailView.tsx
+│   │   │   │   ├── _services
+│   │   │   │   │   ├── attendanceService.ts
+│   │   │   │   │   └── attendanceServiceClient.ts
+│   │   │   │   ├── actions
+│   │   │   │   │   ├── attendance-sync.ts
+│   │   │   │   │   └── attendance-warnings.ts
+│   │   │   │   ├── actions.ts
+│   │   │   │   └── page.tsx
+│   │   │   ├── _components
+│   │   │   │   ├── ChecklistCreateModal.tsx
+│   │   │   │   ├── ChecklistManageModal.tsx
+│   │   │   │   ├── MemberChecklist.tsx
+│   │   │   │   ├── MemberDetailModal.tsx
+│   │   │   │   ├── MemberRating.tsx
+│   │   │   │   ├── MyTeamView.tsx
+│   │   │   │   └── TeamProjectCard.tsx
+│   │   │   ├── AddMembersModal.tsx
+│   │   │   ├── MyTeamPage.tsx
+│   │   │   ├── actions.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── orgchart
+│   │   │   ├── _components
+│   │   │   │   ├── OrgChart.tsx
+│   │   │   │   ├── OrgChartSkeleton.tsx
+│   │   │   │   └── OrgChartTeamMemberCard.tsx
+│   │   │   ├── _types
+│   │   │   │   └── org-chart.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── overflow
+│   │   │   ├── _components
+│   │   │   │   ├── CommentSection.tsx
+│   │   │   │   ├── MentionPopover.tsx
+│   │   │   │   ├── OverflowView.tsx
+│   │   │   │   ├── PostQuestionModal.tsx
+│   │   │   │   ├── QuestionCard.tsx
+│   │   │   │   ├── QuestionFilter.tsx
+│   │   │   │   └── QuestionImagePreview.tsx
+│   │   │   ├── IMPROVEMENTS.md
+│   │   │   ├── actions.ts
+│   │   │   ├── page.tsx
+│   │   │   └── useUserMentions.ts
+│   │   ├── projects
+│   │   │   ├── _components
+│   │   │   │   ├── AddProjectButton.tsx
+│   │   │   │   ├── BookmarkButton.tsx
+│   │   │   │   ├── ImageCrop.tsx
+│   │   │   │   ├── ProjectAddModal.tsx
+│   │   │   │   ├── ProjectCard.tsx
+│   │   │   │   ├── ProjectCardContainer.tsx
+│   │   │   │   ├── ProjectDeleteModal.tsx
+│   │   │   │   ├── ProjectEditModal.tsx
+│   │   │   │   ├── ProjectFilterButton.tsx
+│   │   │   │   ├── ProjectOptionsMenu.tsx
+│   │   │   │   └── ProjectViewModal.tsx
+│   │   │   ├── actions.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── promote-modal
+│   │   │   ├── [id]
+│   │   │   │   └── page.tsx
+│   │   │   ├── _components
+│   │   │   │   ├── EditPromoModal.tsx
+│   │   │   │   ├── FeaturePromoModal.tsx
+│   │   │   │   ├── IconPicker.tsx
+│   │   │   │   └── ModalList.tsx
+│   │   │   ├── actions.ts
+│   │   │   ├── page.tsx
+│   │   │   └── type.ts
+│   │   ├── settings
+│   │   │   ├── _components
+│   │   │   │   └── SettingsCard.tsx
+│   │   │   ├── account-settings
+│   │   │   │   └── page.tsx
+│   │   │   ├── news-banners
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── BannerImageUpload.tsx
+│   │   │   │   │   └── NewsBannerForm.tsx
+│   │   │   │   ├── actions.ts
+│   │   │   │   └── page.tsx
+│   │   │   ├── profile
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── About.tsx
+│   │   │   │   │   ├── ContactInfo.tsx
+│   │   │   │   │   ├── EducationalBackground.tsx
+│   │   │   │   │   ├── Experience.tsx
+│   │   │   │   │   ├── JobStatuses.tsx
+│   │   │   │   │   ├── PersonalInfo.tsx
+│   │   │   │   │   ├── Photo.tsx
+│   │   │   │   │   ├── ProfileCompletionGuide.tsx
+│   │   │   │   │   ├── Skills.tsx
+│   │   │   │   │   ├── TimeSchedule.tsx
+│   │   │   │   │   └── UploadPhotoModal.tsx
+│   │   │   │   ├── action.ts
+│   │   │   │   ├── loading.tsx
+│   │   │   │   └── page.tsx
+│   │   │   ├── services
+│   │   │   │   ├── _components
+│   │   │   │   │   └── ServiceForm.tsx
+│   │   │   │   ├── cms-diagnostic
+│   │   │   │   │   └── page.tsx
+│   │   │   │   ├── diagnostic
+│   │   │   │   │   └── page.tsx
+│   │   │   │   ├── actions.ts
+│   │   │   │   └── page.tsx
+│   │   │   ├── surveys
+│   │   │   │   ├── [surveyId]
+│   │   │   │   │   ├── _components
+│   │   │   │   │   │   └── QuestionForm.tsx
+│   │   │   │   │   ├── results
+│   │   │   │   │   │   └── page.tsx
+│   │   │   │   │   ├── loading.tsx
+│   │   │   │   │   └── page.tsx
+│   │   │   │   ├── _components
+│   │   │   │   │   ├── ShareSurveyModal.tsx
+│   │   │   │   │   ├── SurveyForm.tsx
+│   │   │   │   │   └── SurveyImageUpload.tsx
+│   │   │   │   ├── questions
+│   │   │   │   │   └── actions.ts
+│   │   │   │   ├── responses
+│   │   │   │   │   └── actions.ts
+│   │   │   │   ├── actions.ts
+│   │   │   │   ├── loading.tsx
+│   │   │   │   └── page.tsx
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── surveys
+│   │   │   └── [surveyId]
+│   │   │       ├── loading.tsx
+│   │   │       └── page.tsx
+│   │   ├── tasks
+│   │   │   ├── _components
+│   │   │   │   ├── TaskCard.tsx
+│   │   │   │   ├── TaskViewModal.tsx
+│   │   │   │   └── TasksContainer.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── utils.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── test-meeting-notification
+│   │   │   └── page.tsx
+│   │   ├── test-notifications
+│   │   │   ├── actions.ts
+│   │   │   ├── manual-fetch.tsx
+│   │   │   └── page.tsx
+│   │   ├── ticket-support
+│   │   │   ├── _components
+│   │   │   │   └── TicketSupportForm.tsx
+│   │   │   ├── TICKETSUPPORT.md
+│   │   │   ├── actions.ts
+│   │   │   └── page.tsx
+│   │   ├── time-tracker
+│   │   │   ├── _components
+│   │   │   │   ├── TimeTrackerTable.tsx
+│   │   │   │   ├── TimeTrackerTableDesktop.tsx
+│   │   │   │   └── TimeTrackerTableMobile.tsx
+│   │   │   ├── _lib
+│   │   │   │   └── dummy-data.ts
+│   │   │   ├── _types
+│   │   │   │   └── time-log.ts
+│   │   │   ├── loading.tsx
+│   │   │   └── page.tsx
+│   │   ├── layout.tsx
+│   │   ├── loading.tsx
+│   │   └── page.tsx
+│   ├── nda-signing
+│   │   ├── [token]
+│   │   │   └── page.tsx
+│   │   ├── public
+│   │   │   └── page.tsx
+│   │   └── success
+│   │       └── page.tsx
+│   ├── proposal
+│   │   └── page.tsx
+│   ├── globals.css
+│   ├── layout.tsx
+│   └── not-found.tsx
+├── components
+│   ├── FramerAnimation
+│   │   └── Framer.tsx
+│   ├── leaderboard
+│   │   ├── LeaderboardContainer.tsx
+│   │   ├── LeaderboardError.tsx
+│   │   ├── LeaderboardFilters.tsx
+│   │   ├── LeaderboardLoading.tsx
+│   │   └── LeaderboardTable.tsx
+│   ├── modals
+│   │   ├── ApplicantsEditModal.tsx
+│   │   ├── AvailableTimeModal.tsx
+│   │   ├── AvailableTimeModal2.tsx
+│   │   ├── ContactUsModal.tsx
+│   │   ├── CreatePostModal.tsx
+│   │   ├── DeleteWarningModal.tsx
+│   │   ├── EditPostModal.tsx
+│   │   ├── EditSprintModal.tsx
+│   │   ├── FeedPostModal.tsx
+│   │   ├── PrivacyPolicyModal.tsx
+│   │   ├── PromoteToCodevModal.tsx
+│   │   ├── PromoteToMentorModal.tsx
+│   │   ├── SurveyModal.tsx
+│   │   ├── TechStackModal.tsx
+│   │   ├── TermsOfServiceModal.tsx
+│   │   ├── TimeTrackerModal.tsx
+│   │   └── UserInactiveModal.tsx
+│   ├── notifications
+│   │   ├── NotificationContainer.tsx
+│   │   ├── NotificationIcon.tsx
+│   │   └── NotificationPanel.tsx
+│   ├── providers
+│   │   ├── modal-provider-home.tsx
+│   │   └── modal-provider-marketing.tsx
+│   ├── shared
+│   │   ├── dashboard
+│   │   │   ├── Box.tsx
+│   │   │   ├── BoxInset.tsx
+│   │   │   ├── Button.tsx
+│   │   │   ├── CustomBreadcrumb.tsx
+│   │   │   ├── H1.tsx
+│   │   │   ├── InputPhone.tsx
+│   │   │   ├── InputProfile.tsx
+│   │   │   ├── LeftSidebar.tsx
+│   │   │   ├── MobileNav.tsx
+│   │   │   ├── Navbar.tsx
+│   │   │   ├── RenderTag.tsx
+│   │   │   ├── RenderTeam.tsx
+│   │   │   ├── Search.tsx
+│   │   │   ├── Theme.tsx
+│   │   │   ├── index.js
+│   │   │   ├── input.tsx
+│   │   │   └── theme-mobile.tsx
+│   │   ├── form
+│   │   │   └── FormField.tsx
+│   │   ├── home
+│   │   │   ├── ButtonLink.tsx
+│   │   │   ├── CodevHeading.tsx
+│   │   │   ├── H1.tsx
+│   │   │   ├── H2.tsx
+│   │   │   ├── Heading3.tsx
+│   │   │   ├── IntroText.tsx
+│   │   │   ├── Logo.tsx
+│   │   │   ├── Paragraph.tsx
+│   │   │   ├── SectionWrapper.tsx
+│   │   │   ├── SocialIcons.tsx
+│   │   │   ├── TextGradient.tsx
+│   │   │   └── index.ts
+│   │   ├── Badges.tsx
+│   │   ├── Loader.tsx
+│   │   └── Logo.tsx
+│   ├── time-picker
+│   │   ├── PeriodSelect.tsx
+│   │   ├── TimePicker12hourDemo.tsx
+│   │   ├── TimePicker12hourWrapper.tsx
+│   │   ├── TimePickerDemo.tsx
+│   │   ├── TimePickerInput.tsx
+│   │   ├── TimePickerUtils.tsx
+│   │   └── TimePickerWrapper.tsx
+│   ├── ui
+│   │   ├── carousel
+│   │   │   └── carousel.tsx
+│   │   ├── date
+│   │   │   └── date-picker.tsx
+│   │   ├── forms
+│   │   │   └── input.tsx
+│   │   ├── pagination
+│   │   │   ├── index.tsx
+│   │   │   └── pagination.tsx
+│   │   ├── skeleton
+│   │   │   ├── AdminSkeleton.tsx
+│   │   │   ├── UsersSkeleton.tsx
+│   │   │   └── skeleton.tsx
+│   │   ├── AddNewButton.tsx
+│   │   ├── CustomCheckboxDropdown.tsx
+│   │   ├── CustomSelect.tsx
+│   │   ├── MemberSelection.tsx
+│   │   ├── SwitchStatusButton.tsx
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   ├── chart.tsx
+│   │   ├── dialog.tsx
+│   │   ├── input.tsx
+│   │   ├── label.tsx
+│   │   ├── select.tsx
+│   │   ├── sliders.tsx
+│   │   ├── switch.tsx
+│   │   ├── table.tsx
+│   │   ├── textarea-home.tsx
+│   │   ├── textarea.tsx
+│   │   ├── toaster.tsx
+│   │   ├── toggle.tsx
+│   │   ├── tooltip.tsx
+│   │   ├── use-toast.tsx
+│   │   └── visuallyHidden.tsx
+│   ├── AsyncErrorBoundary.tsx
+│   ├── CodevBadge.tsx
+│   ├── DefaultAvatar.tsx
+│   ├── ErrorBoundary.tsx
+│   └── ProjectAvatar.tsx
+├── config
+│   ├── app.config.ts
+│   └── paths.config.ts
+├── constants
+│   ├── employement.ts
+│   ├── index.ts
+│   ├── internal_status.ts
+│   ├── landing_data.ts
+│   ├── links.ts
+│   ├── navigation.ts
+│   ├── pagination.ts
+│   ├── profile.ts
+│   ├── services.ts
+│   ├── settings.ts
+│   ├── sidebar.ts
+│   ├── social.ts
+│   └── techstack.ts
+├── context
+│   ├── ThemeProvider.tsx
+│   └── ToasterProvider.tsx
+├── docs
+│   ├── VIDEO_UPLOAD_GUIDE.md
+│   └── notification-system.md
+├── hooks
+│   ├── reactQuery.tsx
+│   ├── requestHandler.ts
+│   ├── toastHandler.ts
+│   ├── use-media-query.ts
+│   ├── use-modal-applicants.tsx
+│   ├── use-modal-clients.tsx
+│   ├── use-modal-projects.tsx
+│   ├── use-modal-services.tsx
+│   ├── use-modal-sprints.tsx
+│   ├── use-modal-users.tsx
+│   ├── use-modal.tsx
+│   ├── use-pagination.ts
+│   ├── use-sidebar.ts
+│   ├── use-techstack.ts
+│   ├── use-timeavail.ts
+│   ├── useChangeBgNavigation.ts
+│   ├── useCountries.ts
+│   ├── useDragAndDrop.ts
+│   ├── useFadeAnimation.ts
+│   ├── useHideSidebarOnResize.ts
+│   ├── useImageCrop.tsx
+│   ├── useKanbanTaskUrlModal.ts
+│   ├── useLeaderboard.ts
+│   ├── usePageAnimationSettings.ts
+│   ├── useSlider.ts
+│   └── useToast.ts
+├── lib
+│   ├── actions
+│   │   ├── notification.actions.ts
+│   │   └── notification.ts
+│   ├── server
+│   │   ├── codev.service.ts
+│   │   ├── notification.service.ts
+│   │   ├── project.service.ts
+│   │   ├── redis-cache-keys.ts
+│   │   ├── redis-cache.ts
+│   │   ├── redis.ts
+│   │   ├── supabase-action.ts
+│   │   └── supabase-server-comp.ts
+│   ├── validations
+│   │   ├── auth.ts
+│   │   └── contact-us.ts
+│   ├── form-data.ts
+│   ├── format-date-time.ts
+│   ├── getRandomColor.ts
+│   └── utils.ts
+├── public
+│   ├── assets
+│   │   ├── images
+│   │   │   ├── ai-integration
+│   │   │   │   └── index.ts
+│   │   │   ├── applicant-workflow
+│   │   │   ├── campaign
+│   │   │   ├── index
+│   │   │   ├── onboarding
+│   │   │   │   └── animation
+│   │   │   │       ├── confetti.json
+│   │   │   │       ├── dev-coding.json
+│   │   │   │       ├── developer-01-whoooa.json
+│   │   │   │       ├── infinite_road.json
+│   │   │   │       └── web-development.json
+│   │   │   ├── partners
+│   │   │   ├── services
+│   │   │   │   └── index.ts
+│   │   │   └── index.js
+│   │   └── svgs
+│   │       ├── badges
+│   │       ├── logos
+│   │       ├── techstack
+│   │       │   └── index.js
+│   │       └── index.js
+│   └── site.webmanifest
+├── scripts
+│   ├── apply-pending-migrations.sql
+│   ├── archive-passed-applicants.ts
+│   ├── clear-cache.ts
+│   ├── reset-video-progress.ts
+│   └── run-migrations.ts
+├── store
+│   ├── UserProvider.ts
+│   ├── codev-store.ts
+│   ├── feeds-store.ts
+│   ├── kanban-store.ts
+│   ├── notification-store.ts
+│   ├── sidebar-store.ts
+│   └── sprints-store.ts
+├── styles
+│   ├── tailwind.css
+│   └── theme.css
+├── supabase
+│   └── migrations
+│       ├── 20250108_fix_missing_attendance_points_trigger.sql
+│       ├── 20250118_add_meeting_schedule_to_projects.sql
+│       ├── 20250118_create_attendance_tables.sql
+│       ├── 20250118_fix_notification_preferences.sql
+│       ├── 20250119_add_excused_status_to_attendance.sql
+│       ├── 20250119_create_meetings_table.sql
+│       ├── 20251127_project_category_many_to_many.sql
+│       ├── 20260219_create_client_outreach_tracker.sql
+│       ├── 20260219_critical_security_fixes.sql
+│       ├── 20260219_drop_obsolete_social_points_rpc.sql
+│       ├── 20260219_rls_critical_fixes.sql
+│       ├── 20260219_rls_critical_fixes_v2.sql
+│       ├── 20260219_rls_hotfix.sql
+│       ├── 20260219_rls_hotfix_no_view.sql
+│       ├── 20260219_rls_remove_duplicates.sql
+│       ├── 20260219_schema_fixes.sql
+│       ├── 20260220_add_job_link_to_client_outreach.sql
+│       ├── 20260220_auto_archive_applicant_on_passed.sql
+│       ├── 20260223_add_conversation_image_to_client_outreach.sql
+│       ├── 20260223_add_waitlist_entered_at.sql
+│       ├── 20260224_make_client_name_optional.sql
+│       ├── 20260309_create_ticket_support_table.sql
+│       ├── README.md
+│       ├── RLS_POLICY_TEMPLATES.md
+│       ├── add_dummy_news_banners.sql
+│       ├── add_image_url_to_news_banners.sql
+│       ├── add_quiz_and_commitment_fields.sql
+│       ├── create_in_app_survey_system.sql
+│       ├── create_news_banner_system.sql
+│       ├── create_notification_system.sql
+│       ├── create_onboarding_videos_table.sql
+│       ├── create_proposal_system.sql
+│       ├── create_survey_dismissals.sql
+│       ├── create_survey_system.sql
+│       ├── fix_attendance_warning_for_new_members.sql
+│       ├── fix_notification_rls_policies.sql
+│       ├── reset_onboarding_progress.sql
+│       └── simple_notification_fix.sql
+├── types
+│   ├── database
+│   │   └── applicant.ts
+│   ├── home
+│   │   └── codev.ts
+│   ├── database.ts
+│   ├── leaderboard.ts
+│   ├── notifications.ts
+│   ├── profile-points.ts
+│   └── react-signature-canvas.d.ts
+├── utils
+│   ├── supabase
+│   │   ├── _expr_middleware.ts
+│   │   ├── admin.ts
+│   │   ├── check-env-vars.ts
+│   │   ├── client.tsx
+│   │   ├── ensure-env.ts
+│   │   └── server.ts
+│   ├── codev-priority.ts
+│   ├── codev-qualification.ts
+│   ├── debounce.ts
+│   ├── imageValidation.ts
+│   ├── nda-helpers.ts
+│   ├── ndaStorageService.ts
+│   └── uploadImage.ts
+├── APPLICANT_STATUS_FIX.md
+├── README.md
+├── components.json
+├── database-schema.md
+├── env.mjs
+├── eslint.config.js
+├── fix-applicants.ts
+├── middleware.ts
+├── next-env.d.ts
+├── next.config.mjs
+├── package.json
+├── patch.js
+├── postcss.config.mjs
+├── reset.d.ts
+├── svgr.d.ts
+├── tailwind.config.ts
+├── tree_output.txt
+├── ts_errors.txt
+└── tsconfig.json
+
+277 directories, 969 files


### PR DESCRIPTION
This feature adds a Sub Lead field to the Edit Project form. You can pick any project member as the sublead.  The sublead's name also shows up in the Project Details view so the whole team knows who to go to.

New role: "sublead" value written to project_members table — no migration needed, role column is plain text with no CHECK constraint

<img width="673" height="600" alt="Screenshot 2026-04-14 at 1 18 03 PM" src="https://github.com/user-attachments/assets/351a230a-a503-42af-b2f2-37fb86defc2b" />
