### PR TITLE
Kris/fix leaderboard and auth

### DIFF
--- a/apps/codebility/app/home/my-team/[projectId]/_components/CompactMemberGrid.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/_components/CompactMemberGrid.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { SimpleMemberData } from "@/app/home/projects/actions";
 import DefaultAvatar from "@/components/DefaultAvatar";
-import { Mail, Phone, Calendar, MapPin, Briefcase, Trophy, RefreshCw } from "lucide-react";
+import { Mail, Calendar, Trophy, RefreshCw, AlertCircle } from "lucide-react";
 import { multipleMoveApplicantToOnboardingAction } from "@/app/home/applicants/_service/action";
 const ATTENDANCE_POINTS_PER_DAY = 2;
 import { getTeamMonthlyAttendancePoints } from "../actions";
@@ -23,23 +23,31 @@ interface MemberPoints {
   };
 }
 
+// Fix #4: Track per-member fetch errors separately from points data
+interface MemberErrors {
+  [codevId: string]: boolean;
+}
+
 const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridProps) => {
   const allMembers = teamLead ? [teamLead, ...members] : members;
+  const memberKey = allMembers.map((m) => m.id).join(",");
   const [memberPoints, setMemberPoints] = useState<MemberPoints>({});
-  const [isLoadingPoints, setIsLoadingPoints] = useState(false); // Automatically loads on mount
+  const [memberErrors, setMemberErrors] = useState<MemberErrors>({});
+  const [isLoadingPoints, setIsLoadingPoints] = useState(false);
   const [monthlyAttendancePoints, setMonthlyAttendancePoints] = useState<{ uniqueCodevIdsPresentDays: { codevId: string; presentDays: number }[]; }>({ uniqueCodevIdsPresentDays: [] });
   const [selectedMember, setSelectedMember] = useState<SimpleMemberData | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const loadedMemberIdsRef = useRef<string>("");
 
   // Load points for all members - runs automatically on mount and can be refreshed
   const loadAllPoints = async () => {
-    if (isLoadingPoints) return; // Prevent multiple simultaneous calls
-    
+    if (isLoadingPoints) return;
+
     setIsLoadingPoints(true);
     const pointsData: MemberPoints = {};
+    const errorsData: MemberErrors = {};
 
     try {
-      // Load points in smaller batches to improve perceived performance
       const batchSize = 3;
       for (let i = 0; i < allMembers.length; i += batchSize) {
         const batch = allMembers.slice(i, i + batchSize);
@@ -48,29 +56,54 @@ const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridPr
             const response = await fetch(`/api/codev/${member.id}/points`);
             if (!response.ok) throw new Error('Failed to fetch');
             const data = await response.json() as { totalPoints?: number; attendancePoints?: number };
-            return { memberId: member.id, data };
+            return { memberId: member.id, data, failed: false };
           } catch (error) {
+            // Fix #4: Record the failure instead of silently substituting 0
             console.warn(`Failed to load points for ${member.id}:`, error);
-            return { memberId: member.id, data: { totalPoints: 0, attendancePoints: 0 } };
+            return { memberId: member.id, data: null, failed: true };
           }
         });
 
         const results = await Promise.all(pointsPromises);
-        
-        results.forEach(({ memberId, data }) => {
-          pointsData[memberId] = {
-            totalPoints: data.totalPoints || 0,
-            attendancePoints: data.attendancePoints || 0
-          };
+
+        results.forEach(({ memberId, data, failed }) => {
+          if (failed || !data) {
+            errorsData[memberId] = true;
+          } else {
+            pointsData[memberId] = {
+              totalPoints: data.totalPoints || 0,
+              attendancePoints: data.attendancePoints || 0,
+            };
+          }
         });
 
-        // Update state after each batch for progressive loading
         setMemberPoints(prev => ({ ...prev, ...pointsData }));
+        setMemberErrors(prev => ({ ...prev, ...errorsData }));
       }
     } catch (error) {
       console.error("Error loading points:", error);
     } finally {
       setIsLoadingPoints(false);
+    }
+  };
+
+  // Retry a single member's points fetch
+  const retryMemberPoints = async (memberId: string) => {
+    setMemberErrors(prev => ({ ...prev, [memberId]: false }));
+    try {
+      const response = await fetch(`/api/codev/${memberId}/points`);
+      if (!response.ok) throw new Error('Failed to fetch');
+      const data = await response.json() as { totalPoints?: number; attendancePoints?: number };
+      setMemberPoints(prev => ({
+        ...prev,
+        [memberId]: {
+          totalPoints: data.totalPoints || 0,
+          attendancePoints: data.attendancePoints || 0,
+        },
+      }));
+    } catch (error) {
+      console.warn(`Retry failed for ${memberId}:`, error);
+      setMemberErrors(prev => ({ ...prev, [memberId]: true }));
     }
   };
 
@@ -85,7 +118,10 @@ const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridPr
 
       if (result.success) {
         setMonthlyAttendancePoints({
-          uniqueCodevIdsPresentDays: result.uniqueCodevIdsPresentDays || []
+          uniqueCodevIdsPresentDays: (result.uniqueCodevIdsPresentDays || []).map(item => ({
+            codevId: item.codevId,
+            presentDays: item.presentDays ?? 0
+          }))
         });
       }
     };
@@ -93,15 +129,14 @@ const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridPr
     loadAttendancePoints();
   }, [projectId]);
 
-  // Automatically load points when component mounts
   useEffect(() => {
-    if (allMembers.length > 0) {
-      loadAllPoints();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run once on mount
+    if (allMembers.length === 0) return;
+    if (memberKey === loadedMemberIdsRef.current) return;
+    loadedMemberIdsRef.current = memberKey;
+    loadAllPoints();
+  }, [memberKey]);
 
-  const hasPointsData = Object.keys(memberPoints).length > 0;
+  const hasPointsData = Object.keys(memberPoints).length > 0 || Object.keys(memberErrors).length > 0;
 
   const handleMemberClick = (member: SimpleMemberData) => {
     setSelectedMember(member);
@@ -115,7 +150,7 @@ const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridPr
 
   return (
     <div className="space-y-4">
-      {/* Refresh Points Button - Shows when data is loaded */}
+      {/* Refresh Points Button */}
       {hasPointsData && !isLoadingPoints && allMembers.length > 0 && (
         <div className="flex justify-end">
           <button
@@ -142,6 +177,7 @@ const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridPr
           const isLead = teamLead?.id === member.id;
           const imageUrl = member.image_url || "/assets/images/default-avatar-200x200.jpg";
           const memberHasPoints = memberPoints[member.id];
+          const memberHasError = memberErrors[member.id];
 
           return (
             <div
@@ -149,97 +185,117 @@ const CompactMemberGrid = ({ members, teamLead, projectId }: CompactMemberGridPr
               onClick={() => handleMemberClick(member)}
               className="relative rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-all duration-200 hover:shadow-md hover:scale-105 hover:border-blue-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-blue-600 overflow-hidden cursor-pointer"
             >
-            {/* Status indicator */}
-            <div className="absolute top-2 right-2 h-2 w-2 rounded-full bg-green-500" title="Active" />
+              {/* Status indicator */}
+              <div className="absolute top-2 right-2 h-2 w-2 rounded-full bg-green-500" title="Active" />
 
-            <div className="flex items-start gap-3">
-              {/* Avatar */}
-              <div className="relative flex-shrink-0">
-                {member.image_url ? (
-                  <Image
-                    src={imageUrl}
-                    alt={`${member.first_name} ${member.last_name}`}
-                    width={48}
-                    height={48}
-                    className="h-12 w-12 rounded-full object-cover"
-                  />
-                ) : (
-                  <DefaultAvatar size={48} />
-                )}
-                {isLead && (
-                  <div className="absolute -bottom-1 -right-1 rounded-full bg-blue-500 px-1.5 py-0.5">
-                    <span className="text-xs font-bold text-white">TL</span>
-                  </div>
-                )}
-              </div>
-
-              {/* Info */}
-              <div className="min-w-0 flex-1">
-                <h4 className="text-sm sm:text-base font-semibold text-gray-900 dark:text-white truncate">
-                  {member.first_name} {member.last_name}
-
-
-                </h4>
-
-                <p className="text-xs sm:text-sm text-gray-600 dark:text-gray-400 truncate">
-                  {member.display_position || "Team Member"}
-                </p>
-
-                {/* Quick stats */}
-                <div className="mt-2 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 text-xs text-gray-500 dark:text-gray-400">
-                  <span className="flex items-center gap-1">
-                    <Calendar className="h-3 w-3 flex-shrink-0" />
-                    {new Date(member.joined_at).getFullYear()}
-                  </span>
-                  <span className="flex items-center gap-1 min-w-0">
-                    <Mail className="h-3 w-3 flex-shrink-0" />
-                    <span className="truncate">{member.email_address.split('@')[0]}</span>
-                  </span>
+              <div className="flex items-start gap-3">
+                {/* Avatar */}
+                <div className="relative flex-shrink-0">
+                  {member.image_url ? (
+                    <Image
+                      src={imageUrl}
+                      alt={`${member.first_name} ${member.last_name}`}
+                      width={48}
+                      height={48}
+                      className="h-12 w-12 rounded-full object-cover"
+                    />
+                  ) : (
+                    <DefaultAvatar size={48} />
+                  )}
+                  {isLead && (
+                    <div className="absolute -bottom-1 -right-1 rounded-full bg-blue-500 px-1.5 py-0.5">
+                      <span className="text-xs font-bold text-white">TL</span>
+                    </div>
+                  )}
                 </div>
-              </div>
-            </div>
 
-            {/* Points and Attendance summary */}
-            {(memberHasPoints || hasPointsData) && (
-              <div className="mt-3 border-t border-gray-100 pt-2 dark:border-gray-700">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 text-xs">
-                    <Trophy className="h-3 w-3 text-yellow-500" />
-                    <span className="text-gray-500">Total Points:</span>
-                    {memberHasPoints ? (
-                      <span className="font-semibold text-gray-900 dark:text-white">
-                        {memberPoints[member.id]?.totalPoints || 0}
-                      </span>
-                    ) : (
-                      <div className="w-8 h-3 bg-gray-200 animate-pulse rounded"></div>
-                    )}
-                  </div>
-                  <div className="text-xs">
-                    <span className="text-gray-500">Attendance:</span>
-                    <span className="ml-1 font-medium text-green-600 dark:text-green-400">
-                      +{(() => {
-                        const found = monthlyAttendancePoints.uniqueCodevIdsPresentDays.find(
-                          item => item.codevId === member.id
-                        );
-                        return found ? found.presentDays * ATTENDANCE_POINTS_PER_DAY : 0;
-                      })()}
+                {/* Info */}
+                <div className="min-w-0 flex-1">
+                  <h4 className="text-sm sm:text-base font-semibold text-gray-900 dark:text-white truncate">
+                    {member.first_name} {member.last_name}
+                  </h4>
+
+                  <p className="text-xs sm:text-sm text-gray-600 dark:text-gray-400 truncate">
+                    {member.display_position || "Team Member"}
+                  </p>
+
+                  {/* Quick stats */}
+                  <div className="mt-2 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 text-xs text-gray-500 dark:text-gray-400">
+                    <span className="flex items-center gap-1">
+                      <Calendar className="h-3 w-3 flex-shrink-0" />
+                      {new Date(member.joined_at).getFullYear()}
+                    </span>
+                    <span className="flex items-center gap-1 min-w-0">
+                      <Mail className="h-3 w-3 flex-shrink-0" />
+                      <span className="truncate">{member.email_address.split('@')[0]}</span>
                     </span>
                   </div>
                 </div>
-                <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-                  <span>This month: </span>
-                  <span className="font-medium text-green-600 dark:text-green-400">
-                    {monthlyAttendancePoints.uniqueCodevIdsPresentDays.find(
-                      item => item.codevId === member.id
-                    )?.presentDays || 0}d
-                  </span>
-                  <span>present</span>
-                </div>
               </div>
-            )}
-          </div>
-        );
-      })}
+
+              {/* Points and Attendance summary */}
+              {(memberHasPoints || memberHasError || hasPointsData) && (
+                <div className="mt-3 border-t border-gray-100 pt-2 dark:border-gray-700">
+                  {/* Fix #4: Show error state with retry instead of silent 0 */}
+                  {memberHasError ? (
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                        <AlertCircle className="h-3 w-3" />
+                        Stats unavailable
+                      </span>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          retryMemberPoints(member.id);
+                        }}
+                        className="flex items-center gap-1 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
+                      >
+                        <RefreshCw className="h-3 w-3" />
+                        Retry
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 text-xs">
+                          <Trophy className="h-3 w-3 text-yellow-500" />
+                          <span className="text-gray-500">Total Points:</span>
+                          {memberHasPoints ? (
+                            <span className="font-semibold text-gray-900 dark:text-white">
+                              {memberPoints[member.id]?.totalPoints || 0}
+                            </span>
+                          ) : (
+                            <div className="w-8 h-3 bg-gray-200 animate-pulse rounded"></div>
+                          )}
+                        </div>
+                        <div className="text-xs">
+                          <span className="text-gray-500">Attendance:</span>
+                          <span className="ml-1 font-medium text-green-600 dark:text-green-400">
+                            +{(() => {
+                              const found = monthlyAttendancePoints.uniqueCodevIdsPresentDays.find(
+                                item => item.codevId === member.id
+                              );
+                              return found ? found.presentDays * ATTENDANCE_POINTS_PER_DAY : 0;
+                            })()}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+                        <span>This month: </span>
+                        <span className="font-medium text-green-600 dark:text-green-400">
+                          {monthlyAttendancePoints.uniqueCodevIdsPresentDays.find(
+                            item => item.codevId === member.id
+                          )?.presentDays || 0}d
+                        </span>
+                        <span>present</span>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* Member Detail Modal */}

--- a/apps/codebility/app/home/my-team/[projectId]/_components/TeamDetailView.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/_components/TeamDetailView.tsx
@@ -133,6 +133,9 @@ const TeamDetailView = ({ projectData }: TeamDetailViewProps) => {
       .filter(Boolean)
       .join(", ");
     const convertTo12Hour = (time24: string) => {
+      if (!time24 || !/^\d{1,2}:\d{2}$/.test(time24.trim())) {
+          return time24 || "—";
+        }
       const parts = time24.split(":");
       const hours = parts[0] || "0";
       const minutes = parts[1] || "00";

--- a/apps/codebility/app/home/my-team/[projectId]/_components/Top3Showcase.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/_components/Top3Showcase.tsx
@@ -3,8 +3,7 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { Trophy, ArrowRight, User } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Trophy, User, AlertTriangle, RefreshCw } from "lucide-react";
 import { getWeeklyLeaderboard, LeaderboardMember } from "../leaderboard/actions";
 
 interface Contributor {
@@ -23,24 +22,28 @@ export default function Top3Showcase({ projectId }: Top3ShowcaseProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
 
-  useEffect(() => {
-    async function fetchLeaderboard() {
-      setIsLoading(true);
-      setError(false);
-      try {
-        const result = await getWeeklyLeaderboard(projectId);
-        if (result.success && result.data.length > 0) {
-          setLeaders(result.data.slice(0, 3));
-        } else if (!result.success) {
-          setError(true);
-        }
-      } catch (err) {
-        console.error("Failed to fetch leaderboard:", err);
+  const fetchLeaderboard = async () => {
+    setIsLoading(true);
+    setError(false);
+    try {
+      const result = await getWeeklyLeaderboard(projectId);
+      if (result.success && result.data.length > 0) {
+        setLeaders(result.data.slice(0, 3));
+      } else if (!result.success) {
         setError(true);
-      } finally {
-        setIsLoading(false);
+      } else {
+        // success but empty — clear leaders so empty state shows
+        setLeaders([]);
       }
+    } catch (err) {
+      console.error("Failed to fetch leaderboard:", err);
+      setError(true);
+    } finally {
+      setIsLoading(false);
     }
+  };
+
+  useEffect(() => {
     fetchLeaderboard();
   }, [projectId]);
 
@@ -63,7 +66,7 @@ export default function Top3Showcase({ projectId }: Top3ShowcaseProps) {
   return (
     <div className="flex flex-col h-full w-full">
       <div className="relative overflow-hidden rounded-lg bg-white dark:bg-gray-800/50 p-6 shadow-sm border border-gray-200 dark:border-gray-700/50 flex-1 group hover:border-customBlue-500/30 transition-all duration-500">
-        
+
         {/* Codebility Boomerang Backdrop */}
         <div className="absolute -right-4 -bottom-4 opacity-[0.10] dark:opacity-[0.08] pointer-events-none scale-150 rotate-[-15deg] group-hover:scale-[1.6] group-hover:rotate-[-10deg] transition-all duration-700">
           <Image src="/assets/svgs/icon-codebility.svg" width={180} height={180} alt="" className="object-contain" />
@@ -86,6 +89,21 @@ export default function Top3Showcase({ projectId }: Top3ShowcaseProps) {
 
           {isLoading ? (
             <LeaderboardSkeleton />
+          ) : error ? (
+            // Fix #5: Distinct error state — not conflated with "no activity"
+            <div className="flex flex-col items-center justify-center py-8 text-center bg-red-50 dark:bg-red-900/10 rounded-2xl border border-dashed border-red-200 dark:border-red-800">
+              <AlertTriangle className="h-8 w-8 text-red-400 mb-2" />
+              <p className="text-xs font-bold text-red-500 dark:text-red-400 uppercase tracking-widest mb-3">
+                Failed to load leaderboard
+              </p>
+              <button
+                onClick={fetchLeaderboard}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-red-600 dark:text-red-400 border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/20 transition-colors"
+              >
+                <RefreshCw className="h-3 w-3" />
+                Retry
+              </button>
+            </div>
           ) : leaders.length > 0 ? (
             <div className="flex flex-col gap-3">
               {leaders.map((leader, index) => {
@@ -132,13 +150,14 @@ export default function Top3Showcase({ projectId }: Top3ShowcaseProps) {
               })}
             </div>
           ) : (
+            // Empty state — nobody scored this week (not an error)
             <div className="flex flex-col items-center justify-center py-8 text-center bg-gray-50 dark:bg-gray-900/40 rounded-2xl border border-dashed border-gray-200 dark:border-gray-800">
               <User className="h-8 w-8 text-gray-300 mb-2" />
               <p className="text-xs font-bold text-gray-500 dark:text-gray-500 uppercase tracking-widest">No Activity Recorded</p>
             </div>
           )}
 
-          {!isLoading && leaders.length > 0 && (
+          {!isLoading && !error && leaders.length > 0 && (
             <div className="mt-5 text-center">
               <Link href={`/home/my-team/${projectId}/leaderboard`} className="text-xs font-bold uppercase tracking-widest text-customBlue-500 hover:text-customBlue-600 hover:underline transition-all">
                 View all

--- a/apps/codebility/app/home/my-team/[projectId]/leaderboard/actions.ts
+++ b/apps/codebility/app/home/my-team/[projectId]/leaderboard/actions.ts
@@ -41,6 +41,36 @@ export async function getLeaderboardData(
   error?: string;
 }> {
   const supabase = await createClientServerComponent();
+
+  // Fix #3: Verify the caller is authenticated and is a member of this project
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return { success: false, data: [], error: "Unauthorized" };
+  }
+
+  // Resolve auth user to codev record
+  const { data: codevUser, error: codevError } = await supabase
+    .from("codev")
+    .select("id")
+    .ilike("email_address", user.email?.trim() || "")
+    .maybeSingle();
+
+  if (codevError || !codevUser) {
+    return { success: false, data: [], error: "Unauthorized" };
+  }
+
+  // Verify caller is a member of the requested project
+  const { data: membership, error: membershipError } = await supabase
+    .from("project_members")
+    .select("codev_id")
+    .eq("project_id", projectId)
+    .eq("codev_id", codevUser.id)
+    .maybeSingle();
+
+  if (membershipError || !membership) {
+    return { success: false, data: [], error: "Forbidden" };
+  }
+
   const now = new Date();
 
   let startDate: Date;
@@ -135,7 +165,8 @@ export async function getLeaderboardData(
       const memberTasks = taskData?.filter(t => t.codev_id === memberCodevId) || [];
       const tasksCompleted = memberTasks.length;
       const taskPoints = memberTasks.reduce((sum, task) => {
-        if (task.points) return sum + task.points;
+        // Fix #1: Use != null so explicit 0 is respected, not treated as falsy
+        if (task.points != null) return sum + task.points;
         const diff = task.difficulty?.toLowerCase();
         if (diff === "hard") return sum + 200;
         if (diff === "medium") return sum + 100;


### PR DESCRIPTION
Findings addressed: #1, #2, #3, #4, #5, #11

#1 — Task points calculation treats explicit 0 as "no value"

Changed if (task.points) to if (task.points != null) so tasks with 0 points no longer fall through to the difficulty-based default.

#2 — CompactMemberGrid only fetches points once on mount

Replaced the empty dependency array with a stable memberKey derived from member IDs so points re-fetch when the member list changes.

#3 — No authorization check on getLeaderboardData

Added auth guard at the top of the server action. Resolves the caller via getUser(), verifies project membership, and returns Forbidden if the check fails.

#4 — Points API failures silently substituted 0

Added per-member error state. Failed fetches now show "Stats unavailable" with a Retry button instead of showing a misleading 0.

#5 — Top3Showcase error collapsed into empty state

Split error and empty states. A failed fetch now renders a distinct red error card with a Retry button instead of "No Activity Recorded."

#11 — Schedule time formatter had no validation

Added format validation (^\d{1,2}:\d{2}$) to convertTo12Hour so malformed time values render a fallback instead of NaN.