### PR TITLE
Kris/fix leaderboard data layer

### DIFF
--- a/apps/codebility/app/home/my-team/[projectId]/leaderboard/actions.ts
+++ b/apps/codebility/app/home/my-team/[projectId]/leaderboard/actions.ts
@@ -7,7 +7,8 @@ import {
   startOfMonth,
   endOfMonth,
   subWeeks,
-  subMonths
+  subMonths,
+  format
 } from "date-fns";
 
 export type LeaderboardTimeRange = "this-week" | "last-week" | "this-month" | "last-month";
@@ -120,35 +121,40 @@ export async function getLeaderboardData(
     const codevIds = projectMembers.map((pm) => pm.codev_id);
 
     // 2. Fetch Attendance for the period
+    // Fix #8: Use format() from date-fns instead of toISOString().split("T")[0]
+    // to avoid UTC conversion causing off-by-one errors at DST boundaries
     const { data: attendanceData, error: attendanceError } = await supabase
       .from("attendance")
       .select("*")
       .eq("project_id", projectId)
       .in("codev_id", codevIds)
-      .gte("date", startDate.toISOString().split("T")[0])
-      .lte("date", endDate.toISOString().split("T")[0]);
+      .gte("date", format(startDate, "yyyy-MM-dd"))
+      .lte("date", format(endDate, "yyyy-MM-dd"));
 
     if (attendanceError) throw attendanceError;
 
     // 3. Fetch Completed Tasks for the period
+    // Fix #10: Select only needed columns instead of select("*") to reduce bandwidth
+    // Fix #7: Fetch all tasks updated in the period and filter completed status in JS
+    // instead of using the brittle foreignTable or() filter
     const { data: taskData, error: tasksError } = await supabase
       .from("tasks")
-      .select(`
-        *,
-        kanban_column:kanban_columns!inner(
-          name,
-          board:kanban_boards!inner(project_id)
-        )
-      `)
+      .select("codev_id, points, difficulty, updated_at, kanban_column:kanban_columns!inner(name, board:kanban_boards!inner(project_id))")
       .eq("kanban_column.board.project_id", projectId)
       .in("codev_id", codevIds)
-      .or('name.ilike.Done,name.ilike.Completed', { foreignTable: 'kanban_columns' })
       .gte("updated_at", startDate.toISOString())
       .lte("updated_at", endDate.toISOString());
 
     if (tasksError) {
       console.warn("Task fetch error:", tasksError);
     }
+
+    // Fix #7: Filter completed tasks in JS — handles column name variations like
+    // "Done ✅", "Completed Tasks", "Done & Verified" that the DB filter missed
+    const completedTaskData = (taskData ?? []).filter((task) => {
+      const columnName = (task.kanban_column as any)?.name?.toLowerCase() ?? "";
+      return columnName.includes("done") || columnName.includes("complete");
+    });
 
     // 4. Calculate Points for each member
     const leaderboard: LeaderboardMember[] = projectMembers.map((pm) => {
@@ -157,12 +163,14 @@ export async function getLeaderboardData(
 
       // Attendance Calculation
       const memberAttendance = attendanceData?.filter(a => a.codev_id === memberCodevId) || [];
-      const presentCount = memberAttendance.filter(a => a.status === "present").length;
-      const lateCount = memberAttendance.filter(a => a.status === "late").length;
+      // Fix #9: Normalize status to lowercase before comparing to handle
+      // NULL status and differently-cased values like "PRESENT"
+      const presentCount = memberAttendance.filter(a => a.status?.toLowerCase() === "present").length;
+      const lateCount = memberAttendance.filter(a => a.status?.toLowerCase() === "late").length;
       const attPoints = (presentCount * 10) + (lateCount * 5);
 
-      // Task Completion Calculation
-      const memberTasks = taskData?.filter(t => t.codev_id === memberCodevId) || [];
+      // Task Completion Calculation — uses JS-filtered completed tasks (Fix #7)
+      const memberTasks = completedTaskData.filter(t => t.codev_id === memberCodevId);
       const tasksCompleted = memberTasks.length;
       const taskPoints = memberTasks.reduce((sum, task) => {
         // Fix #1: Use != null so explicit 0 is respected, not treated as falsy

--- a/apps/codebility/app/home/projects/_components/ProjectEditModal.tsx
+++ b/apps/codebility/app/home/projects/_components/ProjectEditModal.tsx
@@ -1,1129 +1,948 @@
-"use server";
+"use client";
 
-import { revalidatePath } from "next/cache";
-import { Client, Codev, Project } from "@/types/home/codev";
-import { deleteImage, getImagePath } from "@/utils/uploadImage";
-import { createClientServerComponent } from "@/utils/supabase/server";
-import { invalidateCache } from "@/lib/server/redis-cache";
-import { cacheKeys } from "@/lib/server/redis-cache-keys";
+import { ChangeEvent, useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import Image from "next/image";
+import {
+  getProjectCategories,
+  getProjectClients,
+  getProjectCodevs,
+  updateProject,
+} from "@/app/home/projects/actions";
+import ProjectAvatar from "@/components/ProjectAvatar";
+import { CustomSelect } from "@/components/ui/CustomSelect";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { MemberSelection } from "@/components/ui/MemberSelection";
+import { Skeleton } from "@/components/ui/skeleton/skeleton";
+import { useModal as useGlobalModal } from "@/hooks/use-modal";
+import { useModal } from "@/hooks/use-modal-projects";
+import { useTechStackStore } from "@/hooks/use-techstack";
+import { Client, Codev, Project, SkillCategory } from "@/types/home/codev";
+import { uploadImage } from "@/utils/uploadImage";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
 
-interface DbProjectMember {
-  project: {
-    id: string;
-    name: string;
-    status: string;
-    kanban_display: boolean;
-    public_display: boolean
-  };
-  role: string;
-  joined_at: string;
+import { Button } from "@codevs/ui/button";
+import { Input } from "@codevs/ui/input";
+
+// Dynamically import the ImageCrop component with no SSR
+const ImageCrop = dynamic(() => import("./ImageCrop"), {
+  ssr: false,
+  loading: () => <Skeleton className="h-48 w-full rounded-lg" />,
+});
+
+// Define the available project statuses.
+const PROJECT_STATUSES = [
+  { id: "pending", value: "pending", label: "Pending" },
+  { id: "inprogress", value: "inprogress", label: "In Progress" },
+  { id: "completed", value: "completed", label: "Completed" },
+];
+
+export interface ProjectFormData {
+  name: string;
+  description?: string;
+  tagline?: string;
+  key_features?: string;
+  gallery?: string;
+  github_link?: string;
+  website_url?: string;
+  figma_link?: string;
+  start_date: string;
+  category_ids?: number[]; // Changed from project_category_id to support multiple categories
+  client_id?: string;
+  status?: string;
+  main_image?: string;
+  tech_stack?: string[];
 }
 
-interface ProjectMemberData {
-  codev_id: string;
-  role: string;
-}
-
-export interface SimpleMemberData {
-  id: string;
-  first_name: string;
-  last_name: string;
-  email_address: string;
-  display_position: string | null;
-  image_url: string | null;
-  role: string;
-  joined_at: string;
-}
-
-interface ProjectMemberResponse {
-  role: string;
-  joined_at: string;
-  codev: {
-    id: string;
-    first_name: string;
-    last_name: string;
-    email_address: string;
-    display_position: string | null;
-    image_url: string | null;
-  };
-}
-
-interface DbProjectMemberResponse {
-  role: string;
-  joined_at: string;
-  codev: {
-    id: string;
-    first_name: string;
-    last_name: string;
-    email_address: string;
-    display_position: string | null;
-    image_url: string | null;
-  };
-}
-
-export async function getUserProjects(): Promise<{
-  error: any;
-  data: { project: Project; role: string }[] | null;
-}> {
-  const supabase = await createClientServerComponent();
-  try {
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
-    if (userError || !user) {
-      console.error("Error fetching user:", userError);
-      return { error: { message: "User not authenticated" }, data: null };
-    }
-
-    const { data: codevData, error: codevError } = await supabase
-      .from("codev")
-      .select("id")
-      .eq("email_address", user.email)
-      .single();
-
-    if (codevError || !codevData) {
-      console.error("Error fetching codev_id:", codevError);
-      return { error: { message: "User profile not found" }, data: null };
-    }
-
-    const userCodevId = codevData.id;
-
-    interface DbProject {
-      id: string;
-      name: string;
-      status: string | null;
-      kanban_display: boolean | null;
-      meeting_link: string | null;
-      public_display: boolean | null;
-    }
-
-    interface ProjectMember {
-      project_id: string;
-      role: string;
-      project: DbProject;
-    }
-
-    const { data: projectMembers, error: projectMembersError } = await supabase
-      .from("project_members")
-      .select(
-        `
-        project_id,
-        role,
-        project:project_id (
-          id,
-          name,
-          status,
-          kanban_display,
-          public_display,
-          meeting_link
-        )
-      `,
-      )
-      .eq("codev_id", userCodevId)
-      .in("role", ["team_leader", "member", "sublead"]) as { data: ProjectMember[] | null; error: any };
-
-    if (projectMembersError) {
-      console.error("Error fetching user projects:", projectMembersError);
-      return { error: { message: "Failed to fetch user projects" }, data: null };
-    }
-
-    if (!projectMembers || projectMembers.length === 0) {
-      return { error: null, data: null };
-    }
-
-    const userProjects = projectMembers.map((pm) => ({
-      project: {
-        id: pm.project.id,
-        name: pm.project.name,
-        status: pm.project.status || "pending",
-        kanban_display: pm.project.kanban_display ?? false,
-        public_display: pm.project.public_display ?? false,
-        meeting_link: pm.project.meeting_link ?? null,
-      } as Project,
-      role: pm.role,
-    }));
-
-    return { error: null, data: userProjects };
-  } catch (error) {
-    console.error("Unexpected error fetching user projects:", error);
-    return { error: { message: "Unexpected error occurred" }, data: null };
-  }
-}
-
-export async function createProject(
-  formData: FormData,
-  selectedMembers: Codev[],
-  teamLeaderId: string,
-) {
-  const supabase = await createClientServerComponent();
-
-  try {
-    const techStackData = formData.get("tech_stack");
-    let techStack: string[] | null = null;
-    if (techStackData) {
-      try {
-        techStack = JSON.parse(techStackData as string) as string[];
-      } catch (error) {
-        console.warn("Invalid tech stack data:", error);
-      }
-    }
-
-    const categoryIdsData = formData.get("category_ids");
-    let categoryIds: number[] = [];
-    if (categoryIdsData) {
-      try {
-        categoryIds = JSON.parse(categoryIdsData as string) as number[];
-      } catch (error) {
-        console.warn("Invalid category IDs data:", error);
-      }
-    }
-
-    const keyFeaturesData = formData.get("key_features");
-    let keyFeatures: string[] | null = null;
-    if (keyFeaturesData) {
-      try {
-        keyFeatures = JSON.parse(keyFeaturesData as string) as string[];
-      } catch (error) {
-        console.warn("Invalid key_features data:", error);
-      }
-    }
-
-    const galleryData = formData.get("gallery");
-    let gallery: string[] | null = null;
-    if (galleryData) {
-      try {
-        gallery = JSON.parse(galleryData as string) as string[];
-      } catch (error) {
-        console.warn("Invalid gallery data:", error);
-      }
-    }
-
-    const { data: project, error: projectError } = await supabase
-      .from("projects")
-      .insert({
-        name: formData.get("name"),
-        description: formData.get("description"),
-        tagline: formData.get("tagline"),
-        key_features: keyFeatures,
-        gallery: gallery,
-        github_link: formData.get("github_link"),
-        website_url: formData.get("website_url"),
-        figma_link: formData.get("figma_link"),
-        client_id: formData.get("client_id"),
-        start_date: formData.get("start_date"),
-        main_image: formData.get("main_image"),
-        tech_stack: techStack,
-        status: "pending",
-      })
-      .select()
-      .single();
-
-    if (projectError) throw projectError;
-
-    if (categoryIds.length > 0) {
-      const categoryInserts = categoryIds.map((categoryId) => ({
-        project_id: project.id,
-        category_id: categoryId,
-      }));
-
-      const { error: categoryError } = await supabase
-        .from("project_categories")
-        .insert(categoryInserts);
-
-      if (categoryError) {
-        console.error("Error inserting project categories:", categoryError);
-      }
-    }
-
-    const memberInserts = [
-      {
-        project_id: project.id,
-        codev_id: teamLeaderId,
-        role: "team_leader",
-        joined_at: new Date().toISOString(),
-      },
-      ...selectedMembers
-        .filter((member) => member.id !== teamLeaderId)
-        .map((member) => ({
-          project_id: project.id,
-          codev_id: member.id,
-          role: "member",
-          joined_at: new Date().toISOString(),
-        })),
-    ];
-
-    const { error: membersError } = await supabase
-      .from("project_members")
-      .insert(memberInserts);
-
-    if (membersError) throw membersError;
-
-    const { error: boardError } = await supabase.from("kanban_boards").insert({
-      name: `${project.name} Board`,
-      project_id: project.id,
-      description: `Default board for ${project.name}`,
-    });
-
-    if (boardError) throw boardError;
-
-    await invalidateCache(cacheKeys.projects.all);
-
-    revalidatePath("/projects");
-    revalidatePath("/services");
-    return { success: true, data: project };
-  } catch (error) {
-    console.error("Error creating project:", error);
-    return {
-      success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to create project",
-    };
-  }
-}
-
-export async function updateStatus(
-  status: string,
-  projectId: string,
-) {
-  const supabase = await createClientServerComponent();
-  const { error: projectError } = await supabase
-    .from("projects")
-    .update({ status: status })
-    .eq("id", projectId)
-    .select();
-
-  if (projectError)
-    console.error("Error in updating projects and kanban board:", projectError);
-
-  await invalidateCache(cacheKeys.projects.all);
-
-  revalidatePath("/home/projects");
-  revalidatePath("/services");
-
-  return { success: true, projectId, status };
-}
-
-export async function updateKanbanDisplaySwitch(
-  kanbanDisplay: boolean,
-  projectId: string,
-) {
-  const supabase = await createClientServerComponent();
-  const { error: projectError } = await supabase
-    .from("projects")
-    .update({ kanban_display: kanbanDisplay })
-    .eq("id", projectId)
-    .select();
-
-  if (projectError)
-    console.error("Error in updating projects and kanban board:", projectError);
-
-  return { success: true, projectId, kanbanDisplay };
-}
-
-export async function updatePublicDisplaySwitch(
-  publicDisplay: boolean,
-  projectId: string,
-) {
-  const supabase = await createClientServerComponent();
-  const { error: projectError } = await supabase
-    .from("projects")
-    .update({ public_display: publicDisplay })
-    .eq("id", projectId)
-    .select();
-
-  if (projectError)
-    console.error("Error in updating projects and kanban board:", projectError);
-
-  await invalidateCache(cacheKeys.projects.all);
-
-  revalidatePath("/home/projects");
-  revalidatePath("/services");
-
-  return { success: true, projectId, publicDisplay };
-}
-
-export async function updateProject(projectId: string, formData: FormData) {
-  const supabase = await createClientServerComponent();
-
-  try {
-    const projectMembersData = formData.get("project_members");
-    const projectMembers = projectMembersData
-      ? (JSON.parse(projectMembersData as string) as ProjectMemberData[])
-      : null;
-
-    const techStackData = formData.get("tech_stack");
-    let techStack: string[] | null = null;
-    if (techStackData) {
-      try {
-        techStack = JSON.parse(techStackData as string) as string[];
-      } catch (error) {
-        console.warn("Invalid tech stack data:", error);
-      }
-    }
-
-    const categoryIdsData = formData.get("category_ids");
-    let categoryIds: number[] | null = null;
-    if (categoryIdsData) {
-      try {
-        categoryIds = JSON.parse(categoryIdsData as string) as number[];
-      } catch (error) {
-        console.warn("Invalid category IDs data:", error);
-      }
-    }
-
-    const keyFeaturesData = formData.get("key_features");
-    let keyFeatures: string[] | null = null;
-    if (keyFeaturesData) {
-      try {
-        keyFeatures = JSON.parse(keyFeaturesData as string) as string[];
-      } catch (error) {
-        console.warn("Invalid key_features data:", error);
-      }
-    }
-
-    const galleryData = formData.get("gallery");
-    let gallery: string[] | null = null;
-    if (galleryData) {
-      try {
-        gallery = JSON.parse(galleryData as string) as string[];
-      } catch (error) {
-        console.warn("Invalid gallery data:", error);
-      }
-    }
-
-    const updateData: any = {};
-    for (const [key, value] of formData.entries()) {
-      if (
-        key !== "project_members" &&
-        key !== "tech_stack" &&
-        key !== "category_ids" &&
-        key !== "key_features" &&
-        key !== "gallery"
-      ) {
-        updateData[key] = value;
-      }
-    }
-
-    if (techStack) updateData.tech_stack = techStack;
-    if (keyFeatures) updateData.key_features = keyFeatures;
-    if (gallery) updateData.gallery = gallery;
-
-    const { data: projectData, error: projectError } = await supabase
-      .from("projects")
-      .update({
-        ...updateData,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", projectId)
-      .select();
-
-    if (projectError) {
-      console.error("Supabase error updating project:", projectError);
-      throw projectError;
-    }
-
-    if (projectMembers && Array.isArray(projectMembers)) {
-      const { data: existingMembers, error: membersError } = await supabase
-        .from("project_members")
-        .select("codev_id, joined_at")
-        .eq("project_id", projectId);
-
-      if (membersError) throw membersError;
-
-      const joinedAtMap = new Map(
-        existingMembers?.map(m => [m.codev_id, m.joined_at]) ?? []
-      );
-
-      const { error: deleteError } = await supabase
-        .from("project_members")
-        .delete()
-        .eq("project_id", projectId);
-
-      if (deleteError) throw deleteError;
-
-      const { error: insertError } = await supabase
-        .from("project_members")
-        .insert(
-          projectMembers.map((member: ProjectMemberData) => ({
-            project_id: projectId,
-            codev_id: member.codev_id,
-            role: member.role,
-            joined_at: joinedAtMap.get(member.codev_id) ?? new Date().toISOString(),
-          })),
-        );
-
-      if (insertError) throw insertError;
-    }
-
-    if (categoryIds !== null) {
-      const { error: deleteCategoriesError } = await supabase
-        .from("project_categories")
-        .delete()
-        .eq("project_id", projectId);
-
-      if (deleteCategoriesError) {
-        console.error("Error deleting project categories:", deleteCategoriesError);
-      }
-
-      if (categoryIds.length > 0) {
-        const categoryInserts = categoryIds.map((categoryId) => ({
-          project_id: projectId,
-          category_id: categoryId,
-        }));
-
-        const { error: insertCategoriesError } = await supabase
-          .from("project_categories")
-          .insert(categoryInserts);
-
-        if (insertCategoriesError) {
-          console.error("Error inserting project categories:", insertCategoriesError);
-        }
-      }
-    }
-
-    await invalidateCache(cacheKeys.projects.all);
-
-    revalidatePath("/projects");
-    revalidatePath("/services");
-    return { success: true, data: projectData };
-  } catch (error) {
-    console.error("Error updating project:", error);
-    return {
-      success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to update project",
-    };
-  }
-}
-
-export async function deleteProject(projectId: string) {
-  const supabase = await createClientServerComponent();
-
-  try {
-    const { data: project, error: fetchError } = await supabase
-      .from("projects")
-      .select()
-      .eq("id", projectId)
-      .single();
-
-    if (fetchError) throw fetchError;
-
-    if (project.main_image) {
-      const imagePath = await getImagePath(project.main_image);
-      if (imagePath) {
-        await deleteImage(imagePath, "projects");
-      }
-    }
-
-    const { error: deleteError } = await supabase
-      .from("projects")
-      .delete()
-      .eq("id", projectId);
-
-    if (deleteError) throw deleteError;
-
-    await invalidateCache(cacheKeys.projects.all);
-
-    revalidatePath("/projects");
-    revalidatePath("/services");
-    return { success: true };
-  } catch (error) {
-    console.error("Error deleting project:", error);
-    return {
-      success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to delete project",
-    };
-  }
-}
-
-export const getTeamLead = async (
-  projectId: string,
-): Promise<{
-  error: any;
-  data: SimpleMemberData | null;
-}> => {
-  const supabase = await createClientServerComponent();
-
-  try {
-    const { data, error } = (await supabase
-      .from("project_members")
-      .select(
-        `
-        role,
-        joined_at,
-        codev:codev_id (
-          id,
-          first_name,
-          last_name,
-          email_address,
-          display_position,
-          image_url
-        )
-      `,
-      )
-      .eq("project_id", projectId)
-      .eq("role", "team_leader")
-      .single()) as { data: DbProjectMemberResponse | null; error: any };
-
-    if (error) {
-      console.error("Error fetching team lead:", error);
-      return { error, data: null };
-    }
-
-    if (!data?.codev) {
-      return { error: null, data: null };
-    }
-
-    const teamLead: SimpleMemberData = {
-      id: data.codev.id,
-      first_name: data.codev.first_name,
-      last_name: data.codev.last_name,
-      email_address: data.codev.email_address,
-      display_position: data.codev.display_position,
-      image_url: data.codev.image_url,
-      role: data.role,
-      joined_at: data.joined_at,
-    };
-
-    return { error: null, data: teamLead };
-  } catch (error) {
-    console.error("Unexpected error fetching team lead:", error);
-    return { error, data: null };
-  }
-};
-
-export const getSubLead = async (
-  projectId: string,
-): Promise<{
-  error: any;
-  data: SimpleMemberData | null;
-}> => {
-  const supabase = await createClientServerComponent();
-
-  try {
-    const { data, error } = (await supabase
-      .from("project_members")
-      .select(
-        `
-        role,
-        joined_at,
-        codev:codev_id (
-          id,
-          first_name,
-          last_name,
-          email_address,
-          display_position,
-          image_url
-        )
-      `,
-      )
-      .eq("project_id", projectId)
-      .eq("role", "sublead")
-      .maybeSingle()) as { data: DbProjectMemberResponse | null; error: any };
-
-    if (error) {
-      console.error("Error fetching sublead:", error);
-      return { error, data: null };
-    }
-
-    if (!data?.codev) {
-      return { error: null, data: null };
-    }
-
-    const subLead: SimpleMemberData = {
-      id: data.codev.id,
-      first_name: data.codev.first_name,
-      last_name: data.codev.last_name,
-      email_address: data.codev.email_address,
-      display_position: data.codev.display_position,
-      image_url: data.codev.image_url,
-      role: data.role,
-      joined_at: data.joined_at,
-    };
-
-    return { error: null, data: subLead };
-  } catch (error) {
-    console.error("Unexpected error fetching sublead:", error);
-    return { error, data: null };
-  }
-};
-
-export const getMembers = async (
-  projectId: string,
-): Promise<{
-  error: any;
-  data: SimpleMemberData[] | null;
-}> => {
-  const supabase = await createClientServerComponent();
-
-  try {
-    const { data: projectMembers, error: pmError } = await supabase
-      .from("project_members")
-      .select("codev_id, role, joined_at")
-      .eq("project_id", projectId)
-      .eq("role", "member");
-
-    if (pmError) {
-      console.error("❌ Error fetching project members:", pmError);
-      return { error: pmError, data: null };
-    }
-
-    if (!projectMembers || projectMembers.length === 0) {
-      return { error: null, data: [] };
-    }
-
-    const codevIds = projectMembers.map(pm => pm.codev_id);
-
-    const { data: codevs, error: codevError } = await supabase
-      .from("codev")
-      .select("id, first_name, last_name, email_address, display_position, image_url")
-      .in("id", codevIds);
-
-    if (codevError) {
-      console.error("❌ Error fetching codev details:", codevError);
-      return { error: codevError, data: null };
-    }
-
-    const members = projectMembers.map(pm => {
-      const codev = codevs?.find(c => c.id === pm.codev_id);
-
-      if (!codev) {
-        console.warn(`⚠️ Missing codev record for member: ${pm.codev_id}`);
-        return null;
-      }
-
-      return {
-        id: codev.id,
-        first_name: codev.first_name,
-        last_name: codev.last_name,
-        email_address: codev.email_address,
-        display_position: codev.display_position,
-        image_url: codev.image_url,
-        role: pm.role,
-        joined_at: pm.joined_at,
-      };
-    }).filter(Boolean) as SimpleMemberData[];
-
-    return { error: null, data: members };
-  } catch (error) {
-    console.error("❌ Unexpected error fetching members:", error);
-    return { error, data: null };
-  }
-};
-
-export const updateProjectMembers = async (
-  projectId: string,
-  members: Codev[],
-  teamLeaderId: string,
-): Promise<{ success: boolean; error?: string }> => {
-  console.log('🔧 [updateProjectMembers] Server-side update starting');
-  console.log('   Project ID:', projectId);
-  console.log('   Members to add:', members.length);
-  console.log('   Team Leader ID:', teamLeaderId);
-
-  const supabase = await createClientServerComponent();
-
-  try {
-    const { data: existingMembers, error: fetchError } = await supabase
-      .from("project_members")
-      .select("codev_id, joined_at, role")
-      .eq("project_id", projectId);
-
-    if (fetchError) throw fetchError;
-
-    console.log('   Existing members in DB:', existingMembers?.length ?? 0);
-
-    // Preserve joined_at timestamps
-    const joinedAtMap = new Map(
-      existingMembers?.map(m => [m.codev_id, m.joined_at]) ?? []
-    );
-
-    // Capture sublead row before deletion — My Team has no sublead UI so it
-    // would otherwise be permanently lost on every member update
-    const existingSubLead = existingMembers?.find(m => m.role === "sublead");
-
-    const { error: deleteError } = await supabase
-      .from("project_members")
-      .delete()
-      .eq("project_id", projectId);
-
-    if (deleteError) throw deleteError;
-
-    console.log('   Old members deleted, preparing inserts...');
-
-    const memberInserts = [
-      // Team lead + regular members
-      ...members.map((member) => ({
-        project_id: projectId,
-        codev_id: member.id,
-        role: member.id === teamLeaderId ? "team_leader" : "member",
-        joined_at: joinedAtMap.get(member.id) ?? new Date().toISOString(),
-      })),
-      // Re-insert sublead if one existed — preserves their joined_at too
-      ...(existingSubLead
-        ? [{
-            project_id: projectId,
-            codev_id: existingSubLead.codev_id,
-            role: "sublead" as const,
-            joined_at: existingSubLead.joined_at,
-          }]
-        : []),
-    ];
-
-    console.log('   Inserting members:', memberInserts.length);
-    console.log('   Member IDs:', memberInserts.map(m => m.codev_id));
-    console.log('   Roles:', memberInserts.map(m => m.role));
-
-    const { error: insertError } = await supabase
-      .from("project_members")
-      .insert(memberInserts);
-
-    if (insertError) throw insertError;
-
-    console.log('✅ [updateProjectMembers] Successfully inserted', memberInserts.length, 'members');
-
-    revalidatePath("/projects");
-    return { success: true };
-  } catch (error) {
-    console.error("❌ [updateProjectMembers] Error updating project members:", error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "Unknown error occurred",
-    };
-  }
-};
-
-export const getProjectCodevs = async (filters = {}): Promise<Codev[]> => {
-  const { createClient } = await import("@supabase/supabase-js");
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const ProjectEditModal = () => {
+  const { isOpen, onClose, type, data } = useModal();
+  const { onOpen: openGlobalModal } = useGlobalModal();
+  const {
+    stack: selectedTechStack,
+    clearStack,
+    setStack,
+  } = useTechStackStore();
+  const isModalOpen = isOpen && type === "projectEditModal";
+  const queryClient = useQueryClient();
+
+  // Data states
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
+  const [currentTeamLeader, setCurrentTeamLeader] = useState<Codev | null>(
+    null,
+  );
+  const [selectedMembers, setSelectedMembers] = useState<Codev[]>([]);
+
+  // Image states with optimized loading
+  const [projectImage, setProjectImage] = useState<string | null>(null);
+  const [openImageCropper, setOpenImageCropper] = useState(false);
+  const [croppedImage, setCroppedImage] = useState<string | null>(null);
+  const [croppedFile, setCroppedFile] = useState<File | null>(null);
+  const [imageLoaded, setImageLoaded] = useState(false);
+
+  // Gallery states
+  const [galleryImages, setGalleryImages] = useState<
+    { url: string; file: File }[]
+  >([]);
+
+  // Loading states
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Controlled status state
+  const [selectedStatus, setSelectedStatus] = useState<string>(
+    data?.status || "pending",
   );
 
-  const selectFields = `
-    id,
-    first_name,
-    last_name,
-    email_address,
-    image_url,
-    positions,
-    tech_stacks,
-    display_position,
-    internal_status,
-    role_id
-  `;
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { errors },
+  } = useForm<ProjectFormData>({ mode: "onChange" });
 
-  // Step 1: Fetch users — same logic as Add Members Modal smart filter
-  // This ensures consistency between both modals
-  const queries = [
-    // Mentors (role_id = 5)
-    supabase.from("codev").select(selectFields).eq("role_id", 5),
-    // Admins (role_id = 1)
-    supabase.from("codev").select(selectFields).eq("role_id", 1),
-    // Graduated users (any role_id)
-    supabase.from("codev").select(selectFields).eq("internal_status", "GRADUATED"),
-    // Training/Intern/Onboarding users
-    supabase.from("codev").select(selectFields).in("internal_status", ["TRAINING", "INTERN", "ONBOARDING"]),
-  ];
+  // Fetch users data with React Query - always keep this data cached
+  const { data: users = [], isLoading: isUsersLoading } = useQuery({
+    queryKey: ["projectCodevs"],
+    queryFn: async () => {
+      const result = await getProjectCodevs();
+      return result || [];
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    refetchOnWindowFocus: false,
+  });
 
-  const results = await Promise.all(queries);
+  // Fetch clients data with React Query - always keep this data cached
+  const { data: clients = [], isLoading: isClientsLoading } = useQuery({
+    queryKey: ["projectClients"],
+    queryFn: async () => {
+      const result = await getProjectClients();
+      return result || [];
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    refetchOnWindowFocus: false,
+  });
 
-  const codevMap = new Map<string, any>();
+  // Fetch categories data with React Query - always keep this data cached
+  const { data: categories = [], isLoading: isCategoriesLoading } = useQuery({
+    queryKey: ["projectCategories"],
+    queryFn: async () => {
+      const result = await getProjectCategories();
+      return result || [];
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes
+    refetchOnWindowFocus: false,
+  });
 
-  results.forEach(({ data, error }, index) => {
-    if (error) {
-      console.error(`Error fetching codevs (query ${index}):`, error);
-    } else if (data) {
-      data.forEach(codev => {
-        if (!codevMap.has(codev.id)) {
-          codevMap.set(codev.id, codev);
+  // Only show loading for essential data that blocks form interaction
+  const isDataLoading = false; // Allow form to show immediately
+  const isSelectDataLoading =
+    isUsersLoading || isClientsLoading || isCategoriesLoading;
+
+  // Prepare select options using useMemo
+  const userOptions = useMemo(
+    () =>
+      users.map((user) => ({
+        id: user.id,
+        value: user.id,
+        label: `${user.first_name} ${user.last_name}`,
+        subLabel: user.display_position,
+        imageUrl: user.image_url,
+      })),
+    [users],
+  );
+
+  const clientOptions = useMemo(
+    () =>
+      clients.map((client) => ({
+        id: client.id,
+        value: client.id,
+        label: client.name,
+        subLabel: client.name,
+        imageUrl: client.company_logo,
+      })),
+    [clients],
+  );
+
+  // Populate form fields immediately when modal opens with project data
+  useEffect(() => {
+    if (data && isModalOpen) {
+      // Reset image loading state
+      setImageLoaded(false);
+
+      // Set form values immediately - don't wait for users to load
+      setValue("name", data.name || "");
+      setValue("description", data.description || "");
+      setValue("tagline", data.tagline || "");
+      setValue(
+        "key_features",
+        data.key_features && Array.isArray(data.key_features) ? data.key_features.join(", ") : "",
+      );
+      setValue("github_link", data.github_link || "");
+      setValue("website_url", data.website_url || "");
+      setValue("figma_link", data.figma_link || "");
+      setValue("client_id", data.client_id || "");
+
+      // Set selected categories from the data
+      if (data.categories && Array.isArray(data.categories)) {
+        setSelectedCategoryIds(data.categories.map((cat) => cat.id));
+      } else {
+        setSelectedCategoryIds([]);
+      }
+
+      setValue("status", data.status || "pending");
+      if (data.start_date) {
+        setValue("start_date", data.start_date);
+      }
+      setProjectImage(data.main_image || null);
+      setCroppedImage(data.main_image || null);
+      setSelectedStatus(data.status || "pending");
+
+      // Set tech stack if available
+      if (data.tech_stack && Array.isArray(data.tech_stack)) {
+        setStack(data.tech_stack);
+      } else {
+        clearStack();
+      }
+    }
+  }, [data, setValue, isModalOpen, setStack, clearStack]);
+
+  // Separate useEffect for team member initialization when users data becomes available
+  useEffect(() => {
+    if (data && users.length > 0 && isModalOpen) {
+      // Initialize project members and team leader from project_members
+      if (data.project_members && data.project_members.length > 0) {
+        // Find team leader
+        const teamLeaderMember = data.project_members.find(
+          (pm) => pm.role === "team_leader",
+        );
+        if (teamLeaderMember) {
+          const leader = users.find(
+            (user) => user.id === teamLeaderMember.codev_id,
+          );
+          if (leader) {
+            setCurrentTeamLeader(leader);
+          }
+        }
+
+        // Find regular members
+        const memberIds = data.project_members
+          .filter((pm) => pm.role === "member")
+          .map((pm) => pm.codev_id);
+
+        const memberCodevs = users.filter((user) =>
+          memberIds.includes(user.id),
+        );
+
+        setSelectedMembers(memberCodevs);
+      }
+    }
+  }, [data, users, isModalOpen]);
+
+  // Handler for image change with optimized loading
+  const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    try {
+      setImageLoaded(false);
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      // Use createObjectURL for faster preview
+      const objectUrl = URL.createObjectURL(file);
+      setProjectImage(objectUrl);
+      setCroppedImage(objectUrl);
+      setCroppedFile(file);
+      setOpenImageCropper(true);
+    } catch (error) {
+      console.error("Failed to upload image:", error);
+      toast.error("Failed to upload image");
+    }
+  };
+
+  // Handler for image removal
+  const handleRemoveImage = () => {
+    setProjectImage(null);
+    setValue("main_image", undefined);
+    setCroppedImage(null);
+    setCroppedFile(null);
+    setImageLoaded(false);
+  };
+
+  const resetForm = () => {
+    reset();
+    setProjectImage(null);
+    setCroppedImage(null);
+    setCroppedFile(null);
+    setGalleryImages([]);
+    setSelectedMembers([]);
+    setCurrentTeamLeader(null);
+    setImageLoaded(false);
+    clearStack(); // Clear tech stack selection
+    onClose();
+  };
+
+  // Subcomponent: ImageUploadSection with optimized loading
+  const ImageUploadSection = () => (
+    <div className="flex flex-col items-center gap-6">
+      {/* Image Preview */}
+      <div className="relative w-full max-w-md">
+        {croppedImage ? (
+          <div className="relative h-48 w-full overflow-hidden rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600">
+            {!imageLoaded && (
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-200 dark:bg-gray-700">
+                <Skeleton className="h-full w-full" />
+              </div>
+            )}
+            <Image
+              src={croppedImage}
+              alt="Project Preview"
+              fill
+              className={`cursor-pointer object-cover transition-opacity hover:opacity-80 ${
+                imageLoaded ? "opacity-100" : "opacity-0"
+              }`}
+              onClick={() => setOpenImageCropper(true)}
+              onLoad={() => setImageLoaded(true)}
+            />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity hover:opacity-100">
+              <span className="text-sm font-medium text-white">
+                Click to edit
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-48 w-full flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:border-gray-600 dark:bg-gray-800">
+            <ProjectAvatar size={64} />
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No image selected
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Upload Controls */}
+      <div className="flex gap-3">
+        <label
+          htmlFor="image-upload"
+          className="inline-flex cursor-pointer items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          {croppedImage ? "Change Image" : "Upload Image"}
+        </label>
+        <input
+          id="image-upload"
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleImageChange}
+        />
+        {projectImage && (
+          <button
+            type="button"
+            onClick={handleRemoveImage}
+            className="inline-flex items-center rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+
+      <ImageCrop
+        image={projectImage || ""}
+        setImage={setCroppedImage}
+        setFile={setCroppedFile}
+        open={openImageCropper}
+        setOpen={setOpenImageCropper}
+      />
+    </div>
+  );
+
+  // Subcomponent: ProjectDetailsSection
+  const ProjectDetailsSection = () => (
+    <div className="space-y-6">
+      {/* Basic Information */}
+      <div className="grid gap-4">
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Project Name *
+          </label>
+          <Input
+            type="text"
+            placeholder="Enter a descriptive project name"
+            {...register("name", { required: "Project name is required" })}
+            className="h-11 border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+          />
+          {errors.name && (
+            <p className="flex items-center gap-1 text-sm text-red-500">
+              <span className="h-4 w-4 text-red-500">⚠</span>
+              {errors.name.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Tagline
+          </label>
+          <Input
+            type="text"
+            placeholder="A catchy tagline for your project"
+            {...register("tagline")}
+            className="h-11 border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Project Description
+          </label>
+          <textarea
+            placeholder="Describe what this project is about, its goals, and key features"
+            {...register("description")}
+            rows={3}
+            className="w-full resize-none rounded-lg border border-gray-300 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Key Features
+          </label>
+          <textarea
+            placeholder="Enter key features separated by commas (e.g., Responsive Design, Modern UI/UX, Cross-platform)"
+            {...register("key_features")}
+            rows={2}
+            className="w-full resize-none rounded-lg border border-gray-300 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Gallery Images
+          </label>
+          <div className="space-y-3">
+            <label
+              htmlFor="gallery-upload"
+              className="inline-flex cursor-pointer items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+            >
+              + Add Gallery Images
+            </label>
+            <input
+              id="gallery-upload"
+              type="file"
+              accept="image/*"
+              multiple
+              className="hidden"
+              onChange={async (e: ChangeEvent<HTMLInputElement>) => {
+                const files = Array.from(e.target.files || []);
+                for (const file of files) {
+                  const objectUrl = URL.createObjectURL(file);
+                  setGalleryImages((prev) => [
+                    ...prev,
+                    { url: objectUrl, file },
+                  ]);
+                }
+                // Reset the input value to allow selecting the same files again
+                e.target.value = '';
+              }}
+            />
+
+            {galleryImages.length > 0 && (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+                {galleryImages.map((image, index) => (
+                  <div key={index} className="group relative">
+                    <div className="relative h-24 w-full overflow-hidden rounded-lg border border-gray-300 dark:border-gray-600">
+                      <Image
+                        src={image.url}
+                        alt={`Gallery ${index + 1}`}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setGalleryImages((prev) =>
+                          prev.filter((_, i) => i !== index),
+                        );
+                      }}
+                      className="absolute -right-2 -top-2 h-6 w-6 rounded-full bg-red-500 text-xs text-white transition-colors hover:bg-red-600"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Start Date
+          </label>
+          <Input
+            type="date"
+            {...register("start_date")}
+            className="h-11 border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+          />
+        </div>
+      </div>
+
+      {/* External Links */}
+      <div className="border-t pt-3">
+        <h4 className="mb-2 text-xs font-medium text-gray-900 dark:text-gray-100">
+          External Links (Optional)
+        </h4>
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              GitHub Repository
+            </label>
+            <Input
+              type="url"
+              placeholder="https://github.com/..."
+              {...register("github_link")}
+              className="h-11 border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              Live Website
+            </label>
+            <Input
+              type="url"
+              placeholder="https://yourproject.com"
+              {...register("website_url")}
+              className="h-11 border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-gray-700 dark:text-gray-300">
+              Figma Design
+            </label>
+            <Input
+              type="url"
+              placeholder="https://figma.com/..."
+              {...register("figma_link")}
+              className="h-11 border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  // Subcomponent: SelectSection
+  const SelectSection = () => (
+    <div className="space-y-6">
+      {/* Project Configuration */}
+      <div className="grid grid-cols-1 gap-4">
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Project Categories * (Select at least one)
+          </label>
+          <div className="grid grid-cols-2 gap-3 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+            {categories.map((category) => (
+              <label
+                key={category.id}
+                className="flex cursor-pointer items-center space-x-2 rounded p-2 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedCategoryIds.includes(category.id)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setSelectedCategoryIds([
+                        ...selectedCategoryIds,
+                        category.id,
+                      ]);
+                    } else {
+                      setSelectedCategoryIds(
+                        selectedCategoryIds.filter((id) => id !== category.id),
+                      );
+                    }
+                  }}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:focus:ring-blue-600"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">
+                  {category.name}
+                </span>
+              </label>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Client *
+          </label>
+          <CustomSelect
+            label="Client"
+            options={clientOptions}
+            onChange={(value) => setValue("client_id", value)}
+            value={data?.client_id || ""}
+            placeholder={
+              isClientsLoading ? "Loading clients..." : "Select Client"
+            }
+            disabled={isClientsLoading}
+            searchable
+          />
+        </div>
+      </div>
+
+      {/* Project Status */}
+      <div className="border-t pt-6">
+        <h4 className="text-md mb-4 font-medium text-gray-900 dark:text-gray-100">
+          Project Status
+        </h4>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+            Status *
+          </label>
+          <CustomSelect
+            label="Status"
+            options={PROJECT_STATUSES}
+            value={selectedStatus}
+            onChange={(value) => setSelectedStatus(value)}
+            placeholder="Select Status"
+            variant="simple"
+          />
+        </div>
+      </div>
+
+      {/* Team Configuration */}
+      <div className="border-t pt-6">
+        <h4 className="text-md mb-4 font-medium text-gray-900 dark:text-gray-100">
+          Team Configuration
+        </h4>
+        <div className="space-y-6">
+          <div className="space-y-1">
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Team Leader *
+            </label>
+            <CustomSelect
+              label="Team Leader"
+              options={userOptions.filter(
+                (user) =>
+                  !selectedMembers.find((member) => member.id === user.value),
+              )}
+              value={currentTeamLeader?.id || ""}
+              onChange={(value) => {
+                const leader = users.find((u) => u.id === value);
+                if (leader) setCurrentTeamLeader(leader);
+              }}
+              placeholder={
+                isUsersLoading ? "Loading users..." : "Select Team Leader"
+              }
+              disabled={isUsersLoading}
+              searchable
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Team Members
+            </label>
+            {isUsersLoading ? (
+              <div className="rounded-lg border border-gray-300 p-4 dark:border-gray-600">
+                <div className="flex items-center gap-2 text-sm text-gray-500">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                  Loading team members...
+                </div>
+              </div>
+            ) : (
+              <MemberSelection
+                users={users.filter(
+                  (user) => user.id !== currentTeamLeader?.id,
+                )}
+                selectedMembers={selectedMembers}
+                onMemberAdd={(member) =>
+                  setSelectedMembers((prev) => [...prev, member])
+                }
+                onMemberRemove={(memberId) =>
+                  setSelectedMembers((prev) =>
+                    prev.filter((m) => m.id !== memberId),
+                  )
+                }
+                excludeMembers={currentTeamLeader ? [currentTeamLeader.id] : []}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Tech Stack Selection */}
+      <div className="border-t pt-6">
+        <h4 className="text-md mb-4 font-medium text-gray-900 dark:text-gray-100">
+          Technology Stack
+        </h4>
+        <div className="space-y-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => openGlobalModal("techStackModal")}
+            className="h-12 w-full justify-start border-2 border-dashed border-gray-300 text-left transition-colors hover:border-blue-500 hover:bg-blue-50 dark:border-gray-600 dark:hover:bg-blue-950"
+          >
+            <div className="flex items-center gap-3">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
+                +
+              </span>
+              {selectedTechStack.length > 0
+                ? `${selectedTechStack.length} technology(ies) selected`
+                : "Select Technologies Used"}
+            </div>
+          </Button>
+
+          {/* Display selected tech stack */}
+          {selectedTechStack.length > 0 && (
+            <div className="rounded-lg bg-blue-50 p-4 dark:bg-blue-950/30">
+              <div className="flex flex-wrap gap-2">
+                {selectedTechStack.map((tech, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center rounded-full bg-blue-600 px-3 py-1 text-sm font-medium text-white shadow-sm"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  const onSubmit = async (formData: ProjectFormData) => {
+    if (!data?.id) {
+      toast.error("Project ID is missing");
+      return;
+    }
+
+    if (!currentTeamLeader) {
+      toast.error("Team leader is required");
+      return;
+    }
+
+    if (!formData.client_id) {
+      toast.error("Client is required");
+      return;
+    }
+
+    if (!selectedCategoryIds || selectedCategoryIds.length === 0) {
+      toast.error("At least one project category is required");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const form = new FormData();
+
+      // Handle image upload if there's a new cropped file
+      if (croppedFile) {
+        console.log("Uploading new image");
+        const uploadResult = await uploadImage(croppedFile, {
+          bucket: "codebility",
+          folder: `projectImage/${Date.now()}_${croppedFile.name.replace(/\s+/g, "_")}`,
+        });
+
+        if (!uploadResult) {
+          throw new Error("Failed to upload image");
+        }
+
+        // Set the new image URL
+        console.log("Setting new main_image:", uploadResult);
+        form.append("main_image", uploadResult);
+      } else if (data.main_image && croppedImage) {
+        // If using existing image without changes
+        console.log("Keeping existing image:", data.main_image);
+        form.append("main_image", data.main_image);
+      }
+
+      // Upload gallery images if provided
+      if (galleryImages.length > 0) {
+        const galleryUrls: string[] = [];
+        for (const galleryImage of galleryImages) {
+          const uploadResult = await uploadImage(galleryImage.file, {
+            bucket: "codebility",
+            folder: `projectGallery/${Date.now()}_${galleryImage.file.name.replace(/\s+/g, "_")}`,
+          });
+          if (uploadResult) {
+            galleryUrls.push(uploadResult);
+          }
+        }
+        if (galleryUrls.length > 0) {
+          form.append("gallery", JSON.stringify(galleryUrls));
+        }
+      }
+
+      // Add form data - make sure we add all fields
+      Object.entries(formData).forEach(([key, value]) => {
+        if (
+          value !== undefined &&
+          value !== null &&
+          value !== "" &&
+          key !== "main_image" &&
+          key !== "gallery"
+        ) {
+          // Handle array fields
+          if (key === "key_features") {
+            const arrayValue = value
+              .split(",")
+              .map((item) => item.trim())
+              .filter(Boolean);
+            if (arrayValue.length > 0) {
+              form.append(key, JSON.stringify(arrayValue));
+            }
+          } else {
+            form.append(key, value);
+          }
         }
       });
+
+      // Add category IDs as JSON array
+      form.append("category_ids", JSON.stringify(selectedCategoryIds));
+
+      // Add tech stack
+      if (selectedTechStack.length > 0) {
+        form.append("tech_stack", JSON.stringify(selectedTechStack));
+      }
+
+      // Add status
+      form.set("status", selectedStatus);
+
+      // Prepare project members with roles
+      const projectMembers = [
+        // Add team leader
+        {
+          codev_id: currentTeamLeader.id,
+          role: "team_leader",
+        },
+        // Add other members
+        ...selectedMembers.map((member) => ({
+          codev_id: member.id,
+          role: "member",
+        })),
+      ];
+
+      form.append("project_members", JSON.stringify(projectMembers));
+
+      console.log("Form data before submission:");
+      // Log the form data to verify all fields are included
+      for (let [key, value] of form.entries()) {
+        console.log(`${key}: ${value}`);
+      }
+
+      const response = await updateProject(data.id, form);
+      if (response.success) {
+        // Invalidate queries to refresh data across components
+        queryClient.invalidateQueries({ queryKey: ["teamLead", data.id] });
+        queryClient.invalidateQueries({ queryKey: ["members", data.id] });
+
+        toast.success("Project updated successfully!");
+        onClose();
+      } else {
+        toast.error(response.error || "Failed to update project");
+      }
+    } catch (error) {
+      console.error("Error updating project:", error);
+      toast.error("Failed to update project");
+    } finally {
+      setIsLoading(false);
     }
-  });
-
-  let codevs = Array.from(codevMap.values());
-
-  if (Object.keys(filters).length > 0) {
-    codevs = codevs.filter(codev => {
-      return Object.entries(filters).every(([key, value]) => {
-        if (value === undefined) return true;
-        return codev[key] === value;
-      });
-    });
-  }
-
-  if (codevs.length === 0) {
-    return [];
-  }
-
-  const codevIds = codevs.map(c => c.id);
-
-  const { data: projectMembers, error: pmError } = await supabase
-    .from("project_members")
-    .select(`
-      codev_id,
-      project_id,
-      role,
-      joined_at,
-      project:project_id (
-        id,
-        name,
-        status,
-        kanban_display,
-        public_display
-      )
-    `)
-    .in("codev_id", codevIds);
-
-  if (pmError) {
-    console.error("Error fetching project members:", pmError);
-  }
-
-  return codevs.map((codev: any) => {
-    const codevProjectMembers = projectMembers?.filter(pm => pm.codev_id === codev.id) || [];
-
-    const projects = codevProjectMembers.map((pm: any) => {
-      const project: Project & { role: string; joined_at: string } = {
-        id: pm.project.id,
-        name: pm.project.name,
-        role: pm.role,
-        joined_at: pm.joined_at,
-        status: pm.project.status,
-        kanban_display: pm.project.kanban_display,
-        public_display: pm.project.public_display,
-      };
-      return project;
-    });
-
-    return {
-      ...codev,
-      positions: codev.positions || [],
-      tech_stacks: codev.tech_stacks || [],
-      projects,
-    } as Codev;
-  });
-};
-
-export const getProjectClients = async (): Promise<Client[]> => {
-  const supabase = await createClientServerComponent();
-
-  const { data, error } = await supabase
-    .from("clients")
-    .select("id, name, email, company_logo");
-
-  if (error) {
-    console.error("Error fetching Clients:", error);
-    throw new Error("Failed to fetch Clients");
-  }
-
-  return data || [];
-};
-
-export const getProjectCategories = async () => {
-  const supabase = await createClientServerComponent();
-  const { data, error } = await supabase
-    .from("projects_category")
-    .select("id, name, description");
-
-  if (error) {
-    console.error("Error fetching categories:", error);
-    throw new Error("Failed to fetch categories");
-  }
-
-  return data || [];
-};
-
-export const getProjectCategoriesForProject = async (projectId: string) => {
-  const supabase = await createClientServerComponent();
-  const { data, error } = await supabase
-    .from("project_categories")
-    .select(`
-      category_id,
-      projects_category (
-        id,
-        name,
-        description
-      )
-    `)
-    .eq("project_id", projectId);
-
-  if (error) {
-    console.error("Error fetching project categories:", error);
-    throw new Error("Failed to fetch project categories");
-  }
-
-  return data?.map((item: any) => item.projects_category).filter(Boolean) || [];
-};
-
-export const addCategoriesToProject = async (
-  projectId: string,
-  categoryIds: number[]
-) => {
-  const supabase = await createClientServerComponent();
-
-  const inserts = categoryIds.map((categoryId) => ({
-    project_id: projectId,
-    category_id: categoryId,
-  }));
-
-  const { error } = await supabase
-    .from("project_categories")
-    .insert(inserts);
-
-  if (error) {
-    console.error("Error adding categories to project:", error);
-    throw new Error("Failed to add categories to project");
-  }
-
-  return { success: true };
-};
-
-export const removeCategoryFromProject = async (
-  projectId: string,
-  categoryId: number
-) => {
-  const supabase = await createClientServerComponent();
-
-  const { error } = await supabase
-    .from("project_categories")
-    .delete()
-    .eq("project_id", projectId)
-    .eq("category_id", categoryId);
-
-  if (error) {
-    console.error("Error removing category from project:", error);
-    throw new Error("Failed to remove category from project");
-  }
-
-  return { success: true };
-};
-
-export const replaceProjectCategories = async (
-  projectId: string,
-  categoryIds: number[]
-) => {
-  const supabase = await createClientServerComponent();
-
-  const { error: deleteError } = await supabase
-    .from("project_categories")
-    .delete()
-    .eq("project_id", projectId);
-
-  if (deleteError) {
-    console.error("Error deleting project categories:", deleteError);
-    throw new Error("Failed to delete project categories");
-  }
-
-  if (categoryIds.length > 0) {
-    const inserts = categoryIds.map((categoryId) => ({
-      project_id: projectId,
-      category_id: categoryId,
-    }));
-
-    const { error: insertError } = await supabase
-      .from("project_categories")
-      .insert(inserts);
-
-    if (insertError) {
-      console.error("Error inserting project categories:", insertError);
-      throw new Error("Failed to insert project categories");
-    }
-  }
-
-  return { success: true };
-};
-
-export async function getAllProjects(kanbanBoardId?: string) {
-  const supabase = await createClientServerComponent();
-
-  try {
-    let query = supabase
-      .from("kanban_boards")
-      .select("id, name, project_id, projects (id, name, main_image)")
-      .eq("projects.kanban_display", true);
-
-    if (kanbanBoardId) {
-      query = query.eq("id", kanbanBoardId);
-    }
-
-    const { data, error } = await query;
-
-    if (error) throw error;
-
-    const flattenedProjects = data.map((item: any) => ({
-      ...item.projects,
-      kanban_board_id: item.id,
-      kanban_board_name: item.name,
-    }));
-
-    return flattenedProjects;
-  } catch (error) {
-    console.error("Error fetching projects:", error);
-    return {
-      success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to fetch projects",
-    };
-  }
-}
-
-export async function getProjectByID(id: string) {
-  const supabase = await createClientServerComponent();
-
-  const { data, error } = await supabase
-    .from("projects")
-    .select(
-      `
-        *,
-        project_members (
-          id,
-          codev_id,
-          role,
-          joined_at
-        ),
-        categories:project_categories(
-          projects_category(
-            id,
-            name,
-            description
-          )
-        )
-      `
-    )
-    .eq("id", id)
-    .single();
-
-  if (error) throw error;
-  if (!data) return null;
-
-  const codevIds = (data.project_members ?? []).map((pm: any) => pm.codev_id);
-
-  let codevMap: Map<string, any> = new Map();
-
-  if (codevIds.length > 0) {
-    const { data: codevs, error: codevError } = await supabase
-      .from("codev")
-      .select("id, first_name, last_name, image_url, display_position, email_address")
-      .in("id", codevIds);
-
-    if (codevError) {
-      console.error("Error fetching codev records for project members:", codevError);
-    } else {
-      codevs?.forEach((c: any) => codevMap.set(c.id, c));
-    }
-  }
-
-  const projectMembersWithCodev = (data.project_members ?? []).map((pm: any) => ({
-    ...pm,
-    codev: codevMap.get(pm.codev_id) ?? null,
-  }));
-
-  return {
-    ...data,
-    project_members: projectMembersWithCodev,
-    categories: data.categories?.map((cat: any) => cat.projects_category).filter(Boolean) || [],
   };
-}
+
+  return (
+    <Dialog open={isModalOpen} onOpenChange={resetForm}>
+      <DialogContent className="max-h-[80vh] max-w-2xl overflow-hidden">
+        <DialogHeader className="border-b pb-2">
+          <DialogTitle className="text-lg font-bold">Edit Project</DialogTitle>
+          <p className="text-xs text-gray-600 dark:text-gray-400">
+            Update the project details below to modify your project.
+          </p>
+        </DialogHeader>
+
+        <div
+          className="flex-1 overflow-y-auto p-3"
+          style={{ maxHeight: "calc(80vh - 200px)" }}
+        >
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            {/* Project Image Section */}
+            <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
+              <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
+                  1
+                </span>
+                Project Image
+              </h3>
+              <ImageUploadSection />
+            </div>
+
+            {/* Project Details Section */}
+            <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
+              <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
+                  2
+                </span>
+                Project Information
+              </h3>
+              <ProjectDetailsSection />
+            </div>
+
+            {/* Team & Configuration Section */}
+            <div className="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
+              <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
+                  3
+                </span>
+                Team & Configuration
+                {isSelectDataLoading && (
+                  <div className="ml-2 flex items-center gap-2 text-sm text-gray-500">
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />
+                    Loading...
+                  </div>
+                )}
+              </h3>
+              <SelectSection />
+            </div>
+          </form>
+        </div>
+
+        <DialogFooter className="border-t bg-gray-50 pt-4 dark:bg-gray-800/30">
+          <div className="flex w-full justify-end gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={resetForm}
+              disabled={isLoading}
+              className="min-w-[100px]"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isLoading}
+              onClick={handleSubmit(onSubmit)}
+              className="min-w-[120px] bg-blue-600 text-white hover:bg-blue-700"
+            >
+              {isLoading ? (
+                <div className="flex items-center gap-2">
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                  Updating...
+                </div>
+              ) : (
+                "Update Project"
+              )}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProjectEditModal;


### PR DESCRIPTION
This branch was created from branch kris/fix-leaderboard-and-auth.

Findings addressed: #7, #8, #9, #10

#7 — Brittle foreign-table or() filter on completed tasks

Removed the fragile .or('name.ilike.Done,name.ilike.Completed', { foreignTable: 'kanban_columns' }) DB filter
Now fetches all tasks in the period and filters completed status in JS using .includes("done") and .includes("complete") — handles column name variations like "Done ✅", "Completed Tasks", "Done & Verified"

#8 — Attendance date filter timezone/DST hazard

Replaced startDate.toISOString().split("T")[0] with format(startDate, "yyyy-MM-dd") from date-fns on both date boundaries
Prevents off-by-one errors at DST transitions by staying in local time

#9 — Attendance status filter no normalization

Changed a.status === "present" to a.status?.toLowerCase() === "present"
Changed a.status === "late" to a.status?.toLowerCase() === "late"
Now correctly counts attendance rows with NULL or differently-cased status values

#10 — Leaderboard task query uses select("*")

Restricted task query to only needed columns: codev_id, points, difficulty, updated_at plus the kanban joins
Reduces response payload size and DB read time