### PR TITLE
PR C — Caching + sublead affordance: #6, #12.

### DIFF
--- a/apps/codebility/app/home/my-team/[projectId]/_components/TeamLeadersDisplay.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/_components/TeamLeadersDisplay.tsx
@@ -42,14 +42,27 @@ const TeamLeadersDisplay = ({ teamLead, subLead }: TeamLeadersDisplayProps) => {
         {/* Team Lead card */}
         <LeaderCard member={teamLead} roleLabel="Lead" />
 
-        {/* Sublead card — or placeholder if none assigned */}
+        {/* Sublead card — or placeholder if none assigned.
+            Sublead assignment is admin-only; the tooltip communicates this
+            so team leads don't hunt for a non-existent edit affordance. */}
         {subLead ? (
           <LeaderCard member={subLead} roleLabel="Sublead" />
         ) : (
-          <div className="flex items-center gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-600 dark:bg-gray-700/30">
+          <div
+            title="Contact your admin to assign a sublead"
+            className="group relative flex cursor-default items-center gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-600 dark:bg-gray-700/30"
+          >
             <Users className="h-5 w-5 text-gray-400" />
             <span className="text-sm text-gray-400 dark:text-gray-500">
               No sublead assigned
+            </span>
+            {/* Visible tooltip on hover — supplements the native title for
+                browsers / screen readers that surface it differently */}
+            <span
+              role="tooltip"
+              className="pointer-events-none absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 dark:bg-gray-700"
+            >
+              Contact your admin to assign a sublead
             </span>
           </div>
         )}

--- a/apps/codebility/app/home/my-team/[projectId]/page.tsx
+++ b/apps/codebility/app/home/my-team/[projectId]/page.tsx
@@ -7,8 +7,7 @@ import { notFound } from "next/navigation";
 import CustomBreadcrumb from "@/components/shared/dashboard/CustomBreadcrumb";
 import { createClientServerComponent } from "@/utils/supabase/server";
 
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
+export const revalidate = 60;
 
 interface TeamDetailPageProps {
   params: Promise<{


### PR DESCRIPTION
Findings addressed: #6, #12

#6 — Replace force-dynamic with 60-second cache (page.tsx)
Before: force-dynamic + revalidate = 0 forced a full DB round-trip on every page navigation — project fetch, leaderboard, and members all re-executed with zero caching.
After: revalidate = 60 lets Next.js serve a cached response for up to 60 seconds. Since the leaderboard is weekly-bucketed, this window is invisible to users. Any mutation that writes member, sublead, or task data must call revalidatePath to bust the cache immediately.

#12 — Sublead empty-state tooltip (TeamLeadersDisplay.tsx)
Before: The "No sublead assigned" placeholder gave no explanation for the missing edit affordance, leaving team leads to wonder if something was broken.
After: Hovering the placeholder shows a tooltip — "Contact your admin to assign a sublead" — making the admin-only restriction explicit. Uses a native title attribute plus a CSS-only Tailwind tooltip; no new dependencies.