### PR TITLE
Replace name-based founder backdoor with role_id check

### DIFF
--- a/apps/codebility/app/home/projects/actions.ts
+++ b/apps/codebility/app/home/projects/actions.ts
@@ -77,40 +77,46 @@ export async function getUserProjects(): Promise<{
     }
 
    
-    const { data: codevData, error: codevError } = await supabase
+    // Look up the caller's codev profile. Try by Supabase auth user id first
+    // (UUID is stable across email changes); fall back to email for legacy
+    // rows seeded before auth.users.id was linked.
+    let { data: codevData, error: codevError } = await supabase
       .from("codev")
-      .select("id, first_name, last_name")
-      .or(`id.eq.${user.id},email_address.eq.${user.email}`)
+      .select("id, role_id")
+      .eq("id", user.id)
       .maybeSingle();
+
+    if (!codevError && !codevData && user.email) {
+      ({ data: codevData, error: codevError } = await supabase
+        .from("codev")
+        .select("id, role_id")
+        .eq("email_address", user.email)
+        .maybeSingle());
+    }
 
     if (codevError) {
       console.error("Error fetching codev profile:", codevError);
       return { error: { message: "Failed to fetch user profile" }, data: null };
     }
 
-    // 2. FOUNDER/ADMIN OVERRIDE
-    // If user is Jzeff Kendrew Somera, grant full access to all projects automatically.
-    const isFounder = codevData?.first_name === "Jzeff Kendrew" && codevData?.last_name === "Somera";
-    
-    if (isFounder) {
+    if (!codevData) {
+      console.error("User profile not found for user:", user.id);
+      return { error: { message: "User profile not found" }, data: null };
+    }
+
+    // Admins get global project visibility for oversight.
+    if (codevData.role_id === 1) {
       const { data: allProjects, error: allProjectsError } = await supabase
         .from("projects")
         .select(`id, name, status, kanban_display, public_display, meeting_link`)
         .neq("status", "deleted");
 
       if (!allProjectsError && allProjects) {
-        const adminProjects = allProjects.map(p => ({
-          project: p as Project,
-          role: "admin",
-        }));
-        return { error: null, data: adminProjects };
+        return {
+          error: null,
+          data: allProjects.map(p => ({ project: p as Project, role: "admin" })),
+        };
       }
-    }
-
-    // 3. Fallback check for missing profile
-    if (!codevData) {
-      console.error("User profile not found for email:", user.email);
-      return { error: { message: "User profile not found" }, data: null };
     }
 
     const userCodevId = codevData.id;
@@ -130,7 +136,6 @@ export async function getUserProjects(): Promise<{
       project: DbProject;
     }
 
-    // 4. Fetch Assigned Projects
     const { data: projectMembers, error: projectMembersError } = await supabase
       .from("project_members")
       .select(`


### PR DESCRIPTION
## Summary

`getUserProjects` in `apps/codebility/app/home/projects/actions.ts` previously granted full admin project access via a hardcoded `first_name === "Jzeff Kendrew" && last_name === "Somera"` match (introduced in #590). Any `codev` row matching those name strings — accidentally or maliciously — would silently inherit founder-level scope.

This PR replaces the name check with the codebase-wide convention `role_id === 1` (Admin), matching how `admin-dashboard`, `Navbar`, `surveys/actions`, and other modules gate admin behavior. Jzeff's row already has `role_id = 1` in production, so this is behavior-preserving for him while closing the bypass for everyone else.

While in the same function, this PR also swaps the unsafe `.or()` interpolation (`id.eq.${user.id},email_address.eq.${user.email}`) for two parameterized `.eq()` lookups — id first, email fallback for legacy rows. Same pattern is documented as a bug in `docs/tasks/Add-Members-Modal-Search-Filter-Bugs.md` (Bug #4).

## Changes

| Before | After |
|---|---|
| `.select("id, first_name, last_name")` + `.or(\`id.eq.${user.id},email_address.eq.${user.email}\`)` | Two `.eq()` queries — id first, email fallback |
| `first_name === "Jzeff Kendrew" && last_name === "Somera"` → admin scope | `codevData.role_id === 1` → admin scope |
| `!codevData` check ran *after* the admin branch (could dereference undefined) | `!codevData` check runs *before* the admin branch |
| Stale numbered comments (`// 2.`, `// 3.`, `// 4.`) | Removed; one short why-comment kept on the admin branch |

## Test plan

- [ ] Sign in as Jzeff (or any `role_id = 1` admin) → projects page lists every non-deleted project with `role = "admin"`.
- [ ] Sign in as a non-admin team_leader → projects page lists only the projects they're a member of.
- [ ] Sign in as a regular codev → only their assigned projects appear.
- [ ] In staging, create a dummy `codev` row with `first_name = "Jzeff Kendrew", last_name = "Somera", role_id = 10` (codev role) → log in as that account → verify they do **not** get global project access (the name no longer grants anything).
- [ ] Sign in with a freshly-created auth user that has no `codev` row yet → see clean "User profile not found" error, not a crash.
- [ ] Change a user's email in Supabase Auth (don't touch `codev.email_address`) → they can still load their projects (id lookup wins).
- [ ] Pull `pnpm typecheck` locally on `apps/codebility` and confirm no new errors appear in `app/home/projects/actions.ts` (171 pre-existing errors in unrelated files are out of scope for this PR).

## Notes for reviewers

- This is a behavior-preserving security fix for Jzeff. No data migration needed — production `codev` row already has `role_id = 1`.
- If a dedicated "Founder/CEO" role is preferred over the existing Admin role, that can be a follow-up — add the role to `roles`, then change `=== 1` to include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)