### PR TITLE
Server action authorization hardening/jury

### DIFF
--- a/apps/codebility/app/api/project-leaderboard/route.ts
+++ b/apps/codebility/app/api/project-leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClientServerComponent } from "@/utils/supabase/server";
 import { z } from "zod";
+import { getWeekRange, getMonthRange } from "@/lib/leaderboard-utils";
 
 interface ProjectLeader {
   project_id: string;
@@ -34,168 +35,98 @@ export async function GET(request: NextRequest) {
 
     let processedLeaders: ProjectLeader[] = [];
 
-    if (timeFilter === "all") {
-      // All-time leaderboard uses the codev_points/project_members relationship for historical data
-      const { data: rawData, error: fallbackError } = await supabase
-        .from("projects")
-        .select(`
-          id,
-          name,
-          project_members(
-            codev_id,
-            codev_points(
-              points,
-              skill_category:skill_category_id(name)
-            )
-          )
-        `);
+    // The tasks table is the single source of truth for points to ensure consistency
+    // across all-time, monthly, and weekly leaderboards.
+    let query = supabase
+      .from("tasks")
+      .select(`
+        points,
+        approved_at,
+        project_id,
+        codev_id,
+        sidekick_ids,
+        project:project_id!inner(name),
+        skill_category:skill_category_id!inner(name)
+      `)
+      .eq("is_archive", true);
 
-      if (fallbackError) {
-        console.error("Error fetching all-time project leaderboard:", fallbackError);
-        return NextResponse.json(
-          { error: "Failed to fetch leaderboard data", details: fallbackError.message },
-          { status: 500 }
-        );
-      }
-
-      const projectMap = new Map<string, {
-        project_id: string;
-        project_name: string;
-        total_points: number;
-        members: Set<string>;
-        skill_breakdown: Record<string, number>;
-      }>();
-
-      rawData?.forEach((project: any) => {
-        const projectId = project.id;
-        if (!projectMap.has(projectId)) {
-          projectMap.set(projectId, {
-            project_id: projectId,
-            project_name: project.name,
-            total_points: 0,
-            members: new Set(),
-            skill_breakdown: {}
-          });
-        }
-        const projectData = projectMap.get(projectId)!;
-
-        project.project_members?.forEach((member: any) => {
-          projectData.members.add(member.codev_id);
-          member.codev_points?.forEach((point: any) => {
-            const skillName = point.skill_category?.name || "Other";
-            const val = point.points || 0;
-            projectData.total_points += val;
-            projectData.skill_breakdown[skillName] = (projectData.skill_breakdown[skillName] || 0) + val;
-          });
-        });
-      });
-
-      processedLeaders = Array.from(projectMap.values())
-        .map(p => ({
-          project_id: p.project_id,
-          project_name: p.project_name,
-          total_points: p.total_points,
-          member_count: p.members.size,
-          skill_breakdown: p.skill_breakdown
-        }))
-        .filter(p => p.total_points > 0)
-        .sort((a, b) => b.total_points - a.total_points)
-        .slice(0, limit);
-
-    } else {
-      // Weekly/Monthly leaderboard calculates points from completed tasks based on approval date (updated_at)
-      const startDate = new Date();
-      if (timeFilter === "weekly") {
-        startDate.setDate(startDate.getDate() - startDate.getDay());
-        startDate.setHours(0, 0, 0, 0);
-      } else {
-        startDate.setDate(1);
-        startDate.setHours(0, 0, 0, 0);
-      }
-
-      const { data: rawTasks, error: tasksError } = await supabase
-        .from("tasks")
-        .select(`
-          points,
-          updated_at,
-          project_id,
-          codev_id,
-          sidekick_ids,
-          project:project_id!inner(name),
-          skill_category:skill_category_id!inner(name)
-        `)
-        .eq("is_archive", true)
-        .gte("updated_at", startDate.toISOString());
-
-      if (tasksError) {
-        console.error(`Error fetching ${timeFilter} project leaderboard tasks:`, tasksError);
-        return NextResponse.json(
-          { error: "Failed to fetch tasks data", details: tasksError.message },
-          { status: 500 }
-        );
-      }
-
-      const projectMap = new Map<string, {
-        project_id: string;
-        project_name: string;
-        total_points: number;
-        members: Set<string>;
-        skill_breakdown: Record<string, number>;
-      }>();
-
-      rawTasks?.forEach((task: any) => {
-        const projectId = task.project_id;
-        if (!projectId) return;
-
-        if (!projectMap.has(projectId)) {
-          projectMap.set(projectId, {
-            project_id: projectId,
-            project_name: task.project?.name || "Unknown Project",
-            total_points: 0,
-            members: new Set(),
-            skill_breakdown: {}
-          });
-        }
-        const projectData = projectMap.get(projectId)!;
-        const skillName = task.skill_category?.name || "Other";
-        const points = task.points || 0;
-        const sidekickPoints = Math.floor(points * 0.5);
-
-        // Add primary assignee points
-        if (task.codev_id) {
-          projectData.members.add(task.codev_id);
-          projectData.total_points += points;
-          projectData.skill_breakdown[skillName] = (projectData.skill_breakdown[skillName] || 0) + points;
-        }
-
-        // Add sidekick points
-        if (task.sidekick_ids && Array.isArray(task.sidekick_ids)) {
-          task.sidekick_ids.forEach((sid: string) => {
-            projectData.members.add(sid);
-            projectData.total_points += sidekickPoints;
-            projectData.skill_breakdown[skillName] = (projectData.skill_breakdown[skillName] || 0) + sidekickPoints;
-          });
-        }
-      });
-
-      processedLeaders = Array.from(projectMap.values())
-        .map(p => ({
-          project_id: p.project_id,
-          project_name: p.project_name,
-          total_points: p.total_points,
-          member_count: p.members.size,
-          skill_breakdown: p.skill_breakdown
-        }))
-        .filter(p => p.total_points > 0)
-        .sort((a, b) => b.total_points - a.total_points)
-        .slice(0, limit);
+    if (timeFilter === "weekly") {
+      const { startDate, endDate } = getWeekRange();
+      query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
+    } else if (timeFilter === "monthly") {
+      const { startDate, endDate } = getMonthRange();
+      query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
     }
+
+    const { data: rawTasks, error: tasksError } = await query;
+
+    if (tasksError) {
+      console.error(`Error fetching ${timeFilter} project leaderboard tasks:`, tasksError);
+      return NextResponse.json(
+        { error: "Failed to fetch tasks data", details: tasksError.message },
+        { status: 500 }
+      );
+    }
+
+    const projectMap = new Map<string, {
+      project_id: string;
+      project_name: string;
+      total_points: number;
+      members: Set<string>;
+      skill_breakdown: Record<string, number>;
+    }>();
+
+    rawTasks?.forEach((task: any) => {
+      const projectId = task.project_id;
+      if (!projectId) return;
+
+      if (!projectMap.has(projectId)) {
+        projectMap.set(projectId, {
+          project_id: projectId,
+          project_name: task.project?.name || "Unknown Project",
+          total_points: 0,
+          members: new Set(),
+          skill_breakdown: {}
+        });
+      }
+      const projectData = projectMap.get(projectId)!;
+      const skillName = task.skill_category?.name || "Other";
+      const points = task.points || 0;
+      const sidekickPoints = Math.floor(points * 0.5);
+
+      // Add primary assignee points
+      if (task.codev_id) {
+        projectData.members.add(task.codev_id);
+        projectData.total_points += points;
+        projectData.skill_breakdown[skillName] = (projectData.skill_breakdown[skillName] || 0) + points;
+      }
+
+      // Add sidekick points
+      if (task.sidekick_ids && Array.isArray(task.sidekick_ids)) {
+        task.sidekick_ids.forEach((sid: string) => {
+          projectData.members.add(sid);
+          projectData.total_points += sidekickPoints;
+          projectData.skill_breakdown[skillName] = (projectData.skill_breakdown[skillName] || 0) + sidekickPoints;
+        });
+      }
+    });
+
+    processedLeaders = Array.from(projectMap.values())
+      .map(p => ({
+        project_id: p.project_id,
+        project_name: p.project_name,
+        total_points: p.total_points,
+        member_count: p.members.size,
+        skill_breakdown: p.skill_breakdown
+      }))
+      .filter(p => p.total_points > 0)
+      .sort((a, b) => b.total_points - a.total_points)
+      .slice(0, limit);
 
     return NextResponse.json({ 
       leaders: processedLeaders,
       totalCount: processedLeaders.length 
     });
-
 
   } catch (error) {
     console.error("API error:", error);

--- a/apps/codebility/app/api/technical-leaderboard/route.ts
+++ b/apps/codebility/app/api/technical-leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClientServerComponent } from "@/utils/supabase/server";
 import { z } from "zod";
+import { getWeekRange, getMonthRange } from "@/lib/leaderboard-utils";
 
 interface TechnicalLeader {
   codev_id: string;
@@ -34,155 +35,106 @@ export async function GET(request: NextRequest) {
 
     let processedLeaders: TechnicalLeader[] = [];
 
-    // All-time leaderboard uses the codev_points running total for performance
-    if (timeFilter === "all") {
-      const { data: rawData, error: fallbackError } = await supabase
-        .from("codev_points")
-        .select(`
-          codev_id,
-          points,
-          created_at,
-          codev:codev_id!inner(first_name),
-          skill_category:skill_category_id!inner(name)
-        `)
-        .eq("skill_category.name", category)
-        .not("codev.first_name", "is", null);
+    // The tasks table is the single source of truth for points to ensure consistency
+    // across all-time, monthly, and weekly leaderboards.
+    let query = supabase
+      .from("tasks")
+      .select(`
+        points,
+        approved_at,
+        codev_id,
+        sidekick_ids,
+        codev:codev_id(first_name),
+        skill_category:skill_category_id!inner(name)
+      `)
+      .eq("skill_category.name", category)
+      .eq("is_archive", true);
 
-      if (fallbackError) {
-        console.error("Error fetching all-time technical leaderboard:", fallbackError);
-        return NextResponse.json(
-          { error: "Failed to fetch leaderboard data", details: fallbackError.message },
-          { status: 500 }
-        );
-      }
+    if (timeFilter === "weekly") {
+      const { startDate, endDate } = getWeekRange();
+      query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
+    } else if (timeFilter === "monthly") {
+      const { startDate, endDate } = getMonthRange();
+      query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
+    }
 
-      // Aggregate points (already aggregated in table, but handling duplicates just in case)
-      const userPointsMap = new Map<string, TechnicalLeader>();
+    const { data: rawTasks, error: tasksError } = await query;
 
-      rawData?.forEach((item: any) => {
-        const userId = item.codev_id;
-        const existing = userPointsMap.get(userId);
-        
+    if (tasksError) {
+      console.error(`Error fetching ${timeFilter} technical leaderboard tasks:`, tasksError);
+      return NextResponse.json(
+        { error: "Failed to fetch tasks data", details: tasksError.message },
+        { status: 500 }
+      );
+    }
+
+    const userPointsMap = new Map<string, { total_points: number; latest_update: string; first_name?: string }>();
+    const involvedUserIds = new Set<string>();
+
+    rawTasks?.forEach((task: any) => {
+      const points = task.points || 0;
+      const sidekickPoints = Math.floor(points * 0.5);
+
+      // Add points to primary assignee
+      if (task.codev_id) {
+        involvedUserIds.add(task.codev_id);
+        const existing = userPointsMap.get(task.codev_id);
         if (existing) {
-          existing.total_points += item.points || 0;
-          if (item.created_at > existing.latest_update) {
-            existing.latest_update = item.created_at;
-          }
+          existing.total_points += points;
+          // Use approved_at instead of updated_at
+          if (task.approved_at && task.approved_at > existing.latest_update) existing.latest_update = task.approved_at;
         } else {
-          userPointsMap.set(userId, {
-            codev_id: userId,
-            first_name: item.codev?.first_name || "Unknown",
-            total_points: item.points || 0,
-            latest_update: item.created_at
+          userPointsMap.set(task.codev_id, {
+            total_points: points,
+            latest_update: task.approved_at || new Date(0).toISOString(),
+            first_name: task.codev?.first_name
           });
         }
-      });
-
-      processedLeaders = Array.from(userPointsMap.values())
-        .filter(leader => leader.total_points > 0)
-        .sort((a, b) => b.total_points - a.total_points)
-        .slice(0, limit);
-
-    } else {
-      // Weekly/Monthly leaderboard calculates points from completed tasks based on approval date (updated_at)
-      const startDate = new Date();
-      if (timeFilter === "weekly") {
-        startDate.setDate(startDate.getDate() - startDate.getDay()); // Sunday
-        startDate.setHours(0, 0, 0, 0);
-      } else {
-        startDate.setDate(1); // 1st of month
-        startDate.setHours(0, 0, 0, 0);
       }
 
-      const { data: rawTasks, error: tasksError } = await supabase
-        .from("tasks")
-        .select(`
-          points,
-          updated_at,
-          codev_id,
-          sidekick_ids,
-          codev:codev_id(first_name),
-          skill_category:skill_category_id!inner(name)
-        `)
-        .eq("skill_category.name", category)
-        .eq("is_archive", true)
-        .gte("updated_at", startDate.toISOString());
-
-      if (tasksError) {
-        console.error(`Error fetching ${timeFilter} technical leaderboard tasks:`, tasksError);
-        return NextResponse.json(
-          { error: "Failed to fetch tasks data", details: tasksError.message },
-          { status: 500 }
-        );
-      }
-
-      const userPointsMap = new Map<string, { total_points: number; latest_update: string; first_name?: string }>();
-      const involvedUserIds = new Set<string>();
-
-      rawTasks?.forEach((task: any) => {
-        const points = task.points || 0;
-        const sidekickPoints = Math.floor(points * 0.5);
-
-        // Add points to primary assignee
-        if (task.codev_id) {
-          involvedUserIds.add(task.codev_id);
-          const existing = userPointsMap.get(task.codev_id);
+      // Add points to sidekicks
+      if (task.sidekick_ids && Array.isArray(task.sidekick_ids)) {
+        task.sidekick_ids.forEach((sidekickId: string) => {
+          involvedUserIds.add(sidekickId);
+          const existing = userPointsMap.get(sidekickId);
           if (existing) {
-            existing.total_points += points;
-            if (task.updated_at > existing.latest_update) existing.latest_update = task.updated_at;
+            existing.total_points += sidekickPoints;
+            if (task.approved_at && task.approved_at > existing.latest_update) existing.latest_update = task.approved_at;
           } else {
-            userPointsMap.set(task.codev_id, {
-              total_points: points,
-              latest_update: task.updated_at,
-              first_name: task.codev?.first_name
+            userPointsMap.set(sidekickId, {
+              total_points: sidekickPoints,
+              latest_update: task.approved_at || new Date(0).toISOString()
             });
           }
-        }
-
-        // Add points to sidekicks
-        if (task.sidekick_ids && Array.isArray(task.sidekick_ids)) {
-          task.sidekick_ids.forEach((sidekickId: string) => {
-            involvedUserIds.add(sidekickId);
-            const existing = userPointsMap.get(sidekickId);
-            if (existing) {
-              existing.total_points += sidekickPoints;
-              if (task.updated_at > existing.latest_update) existing.latest_update = task.updated_at;
-            } else {
-              userPointsMap.set(sidekickId, {
-                total_points: sidekickPoints,
-                latest_update: task.updated_at
-              });
-            }
-          });
-        }
-      });
-
-      // Fetch missing first names (for sidekicks)
-      const missingNameIds = Array.from(involvedUserIds).filter(id => !userPointsMap.get(id)?.first_name);
-      
-      if (missingNameIds.length > 0) {
-        const { data: namesData } = await supabase
-          .from("codev")
-          .select("id, first_name")
-          .in("id", missingNameIds);
-        
-        namesData?.forEach(n => {
-          const user = userPointsMap.get(n.id);
-          if (user) user.first_name = n.first_name;
         });
       }
+    });
 
-      processedLeaders = Array.from(userPointsMap.entries())
-        .map(([id, data]) => ({
-          codev_id: id,
-          first_name: data.first_name || "Unknown",
-          total_points: data.total_points,
-          latest_update: data.latest_update
-        }))
-        .filter(leader => leader.total_points > 0)
-        .sort((a, b) => b.total_points - a.total_points)
-        .slice(0, limit);
+    // Fetch missing first names (for sidekicks)
+    const missingNameIds = Array.from(involvedUserIds).filter(id => !userPointsMap.get(id)?.first_name);
+    
+    if (missingNameIds.length > 0) {
+      const { data: namesData } = await supabase
+        .from("codev")
+        .select("id, first_name")
+        .in("id", missingNameIds);
+      
+      namesData?.forEach(n => {
+        const user = userPointsMap.get(n.id);
+        if (user) user.first_name = n.first_name;
+      });
     }
+
+    processedLeaders = Array.from(userPointsMap.entries())
+      .map(([id, data]) => ({
+        codev_id: id,
+        first_name: data.first_name || "Unknown",
+        total_points: data.total_points,
+        latest_update: data.latest_update
+      }))
+      .filter(leader => leader.total_points > 0)
+      .sort((a, b) => b.total_points - a.total_points)
+      .slice(0, limit);
 
     return NextResponse.json({ 
       leaders: processedLeaders,

--- a/apps/codebility/app/home/(dashboard)/actions.ts
+++ b/apps/codebility/app/home/(dashboard)/actions.ts
@@ -5,6 +5,7 @@ import { createClientServerComponent } from "@/utils/supabase/server";
 
 
 import { z } from "zod";
+import { requireSelfOrRole } from "@/lib/server/auth-guard";
 
 export const updateUserSchedule = async (
   {
@@ -16,7 +17,7 @@ export const updateUserSchedule = async (
   },
   codevId: string,
 ) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireSelfOrRole(codevId, "dashboard");
   const { error } = await supabase
     .from("codev")
     .update({
@@ -29,7 +30,7 @@ export const updateUserSchedule = async (
 };
 
 export const startUserTimer = async (codevId: string) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireSelfOrRole(codevId, "dashboard");
   const currentDate = new Date();
 
   const { error } = await supabase
@@ -43,7 +44,7 @@ export const startUserTimer = async (codevId: string) => {
 };
 
 const stopUserTimer = async (codevId: string) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireSelfOrRole(codevId, "dashboard");
 
   const { error } = await supabase
     .from("codev")
@@ -55,9 +56,9 @@ const stopUserTimer = async (codevId: string) => {
 };
 
 export const logUserTime = async (formData: FormData) => {
-  const supabase = await createClientServerComponent();
-
   const codevId = formData.get("codevId") as string;
+  if (!codevId) throw new Error("codevId is required");
+  const { supabase } = await requireSelfOrRole(codevId, "dashboard");
   const taskId = formData.get("taskId");
 
   const { data: codevData, error: fetchingCodevError } = await supabase
@@ -93,7 +94,7 @@ export const logUserTime = async (formData: FormData) => {
 };
 
 export const updateUserTaskOnHand = async (codevId: string, taskId: string) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireSelfOrRole(codevId, "dashboard");
 
   const formData = new FormData();
   formData.append("codevId", codevId);
@@ -121,7 +122,7 @@ export const updateUserAvailabilityStatus = async ({
 }
 ) => {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase } = await requireSelfOrRole(userId, "dashboard");
 
     const { error } = await supabase
       .from("codev")

--- a/apps/codebility/app/home/in-house/actions.ts
+++ b/apps/codebility/app/home/in-house/actions.ts
@@ -3,6 +3,7 @@
 
 import { Codev } from "@/types/home/codev";
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireRole } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 
 /**
@@ -14,7 +15,7 @@ export const updateCodev = async (
   value: any,
   { codevId }: { codevId: string },
 ) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireRole("inhouse");
 
   // Define keys and their corresponding target tables
   const keys = {
@@ -134,7 +135,7 @@ export const updateNdaUrls = async (
   signatureUrl: string,
   documentUrl: string
 ) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireRole("inhouse");
 
   try {
     const { error } = await supabase
@@ -170,7 +171,7 @@ export const sendNdaEmailAction = async (
   subject: string,
   message: string
 ) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireRole("inhouse");
 
   try {
     // Generate unique token with 7-day expiration
@@ -243,7 +244,7 @@ export const sendNdaEmailAction = async (
  * Handles foreign key relationships and file cleanup
  */
 export const deleteCodevAction = async (codevId: string) => {
-  const supabase = await createClientServerComponent();
+  const { supabase } = await requireRole("inhouse");
 
   try {
     // Get codev data first for cleanup

--- a/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
@@ -568,7 +568,8 @@ export const completeTask = async (
       .from("tasks")
       .update({
         is_archive: true,
-        updated_at: new Date().toISOString()
+        updated_at: new Date().toISOString(),
+        approved_at: new Date().toISOString()
       })
       .eq("id", task.id);
 

--- a/apps/codebility/app/home/my-team/[projectId]/leaderboard/actions.ts
+++ b/apps/codebility/app/home/my-team/[projectId]/leaderboard/actions.ts
@@ -9,6 +9,7 @@ import {
   subWeeks,
   subMonths
 } from "date-fns";
+import { getWeekRange, getMonthRange } from "@/lib/leaderboard-utils";
 
 export type LeaderboardTimeRange = "this-week" | "last-week" | "this-month" | "last-month";
 
@@ -52,20 +53,25 @@ export async function getLeaderboardData(
       startDate = startOfWeek(prevWeek, { weekStartsOn: 1 });
       endDate = endOfWeek(prevWeek, { weekStartsOn: 1 });
       break;
-    case "this-month":
-      startDate = startOfMonth(now);
-      endDate = endOfMonth(now);
+    case "this-month": {
+      const currentMonth = getMonthRange();
+      startDate = currentMonth.startDate;
+      endDate = currentMonth.endDate;
       break;
-    case "last-month":
+    }
+    case "last-month": {
       const prevMonth = subMonths(now, 1);
       startDate = startOfMonth(prevMonth);
       endDate = endOfMonth(prevMonth);
       break;
+    }
     case "this-week":
-    default:
-      startDate = startOfWeek(now, { weekStartsOn: 1 });
-      endDate = endOfWeek(now, { weekStartsOn: 1 });
+    default: {
+      const currentWeek = getWeekRange();
+      startDate = currentWeek.startDate;
+      endDate = currentWeek.endDate;
       break;
+    }
   }
 
   try {
@@ -106,15 +112,14 @@ export async function getLeaderboardData(
       .select(`
         *,
         kanban_column:kanban_columns!inner(
-          name,
           board:kanban_boards!inner(project_id)
         )
       `)
       .eq("kanban_column.board.project_id", projectId)
       .in("codev_id", codevIds)
-      .or('name.ilike.Done,name.ilike.Completed', { foreignTable: 'kanban_columns' })
-      .gte("updated_at", startDate.toISOString())
-      .lte("updated_at", endDate.toISOString());
+      .eq("is_archive", true)
+      .gte("approved_at", startDate.toISOString())
+      .lte("approved_at", endDate.toISOString());
 
     if (tasksError) {
       console.warn("Task fetch error:", tasksError);

--- a/apps/codebility/app/home/my-team/actions.ts
+++ b/apps/codebility/app/home/my-team/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireUser } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 
 // ============================================================================
@@ -12,20 +13,14 @@ import { revalidatePath } from "next/cache";
  * Only team leads can create checklist items
  */
 export async function createChecklistItem(formData: FormData) {
-  const supabase = await createClientServerComponent();
-
   try {
-    // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: "Authentication required" };
-    }
+    const { user, supabase } = await requireUser();
 
     // Get user's codev profile
     const { data: codevProfile, error: codevError } = await supabase
       .from("codev")
       .select("id")
-      .eq("email_address", user.email)
+      .eq("id", user.id)
       .single();
 
     if (codevError || !codevProfile) {
@@ -135,20 +130,14 @@ export async function updateChecklistItem(
     due_date?: string;
   }
 ) {
-  const supabase = await createClientServerComponent();
-
   try {
-    // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: "Authentication required" };
-    }
+    const { user, supabase } = await requireUser();
 
     // Get user's codev profile
     const { data: codevProfile, error: codevError } = await supabase
       .from("codev")
       .select("id")
-      .eq("email_address", user.email)
+      .eq("id", user.id)
       .single();
 
     if (codevError || !codevProfile) {
@@ -217,20 +206,14 @@ export async function updateChecklistItem(
  * Only team leads can delete checklist items
  */
 export async function deleteChecklistItem(itemId: string) {
-  const supabase = await createClientServerComponent();
-
   try {
-    // Get current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: "Authentication required" };
-    }
+    const { user, supabase } = await requireUser();
 
     // Get user's codev profile
     const { data: codevProfile, error: codevError } = await supabase
       .from("codev")
       .select("id")
-      .eq("email_address", user.email)
+      .eq("id", user.id)
       .single();
 
     if (codevError || !codevProfile) {

--- a/apps/codebility/app/home/promote-modal/actions.ts
+++ b/apps/codebility/app/home/promote-modal/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireRole } from "@/lib/server/auth-guard";
 import { FeatureModal } from "./type";
 
 export async function fetchActiveModal(): Promise<FeatureModal | null> {
@@ -55,7 +56,7 @@ export async function upsertActiveModal(
   data: Partial<FeatureModal>
 ): Promise<{ error: string | null }> {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase } = await requireRole("settings");
     const { error } = await supabase.from("feature_modals").upsert({
       ...data,
       updated_at: new Date().toISOString(),
@@ -72,7 +73,7 @@ export async function createModal(): Promise<{
   error: string | null;
 }> {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase } = await requireRole("settings");
     const { data, error } = await supabase
       .from("feature_modals")
       .insert({
@@ -102,7 +103,7 @@ export async function uploadModalImage(
   formData: FormData
 ): Promise<{ url: string | null; error: string | null }> {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase } = await requireRole("settings");
     const file = formData.get("file") as File;
 
     const ext = file.name.split(".").pop();
@@ -129,7 +130,7 @@ export async function deleteModal(
   id: string
 ): Promise<{ error: string | null }> {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase } = await requireRole("settings");
     const { error } = await supabase
       .from("feature_modals")
       .delete()
@@ -146,7 +147,7 @@ export async function toggleModalActive(
   is_active: boolean
 ): Promise<{ error: string | null }> {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase } = await requireRole("settings");
 
     const { error } = await supabase
       .from("feature_modals")

--- a/apps/codebility/app/home/ticket-support/actions.ts
+++ b/apps/codebility/app/home/ticket-support/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireUser } from "@/lib/server/auth-guard";
 
 interface SubmitTicketData {
   userId: string | null;
@@ -17,14 +18,14 @@ interface SubmitTicketData {
 }
 
 export async function submitTicket(data: SubmitTicketData) {
-  const supabase = await createClientServerComponent();
+  const { user, supabase } = await requireUser();
 
   // Generate a ticket number: TIC-XXXXX
   const ticketNumber = `TIC-${Math.floor(10000 + Math.random() * 90000)}`;
 
   const { error } = await supabase.from("ticket_support").insert({
     ticket_number: ticketNumber,
-    user_id: data.userId || null,
+    user_id: user.id,
     full_name: data.fullName,
     email: data.email || null,
     role_position: data.rolePosition || null,

--- a/apps/codebility/lib/leaderboard-utils.ts
+++ b/apps/codebility/lib/leaderboard-utils.ts
@@ -1,0 +1,23 @@
+import { startOfWeek, endOfWeek, startOfMonth, endOfMonth } from "date-fns";
+
+/**
+ * Returns the start and end dates for a week, treating Monday as the first day of the week.
+ */
+export function getWeekRange() {
+  const now = new Date();
+  return {
+    startDate: startOfWeek(now, { weekStartsOn: 1 }),
+    endDate: endOfWeek(now, { weekStartsOn: 1 })
+  };
+}
+
+/**
+ * Returns the start and end dates for the current month.
+ */
+export function getMonthRange() {
+  const now = new Date();
+  return {
+    startDate: startOfMonth(now),
+    endDate: endOfMonth(now)
+  };
+}

--- a/apps/codebility/lib/server/auth-guard.ts
+++ b/apps/codebility/lib/server/auth-guard.ts
@@ -1,0 +1,134 @@
+import { createClientServerComponent } from "@/utils/supabase/server";
+
+export type RolePermissionKey =
+  | "dashboard"
+  | "kanban"
+  | "time_tracker"
+  | "interns"
+  | "applicants"
+  | "inhouse"
+  | "clients"
+  | "projects"
+  | "settings"
+  | "orgchart"
+  | "resume";
+
+/**
+ * Ensures the caller is authenticated.
+ * @returns The authenticated user object and a supabase instance.
+ * @throws Error with message "Unauthorized" if missing.
+ */
+export async function requireUser() {
+  const supabase = await createClientServerComponent();
+  const { data: { user }, error } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    throw new Error("Unauthorized");
+  }
+  return { user, supabase };
+}
+
+/**
+ * Ensures the caller has the required role permission.
+ * Role permission corresponds to columns in the 'roles' table.
+ */
+export async function requireRole(permissionKey: RolePermissionKey) {
+  const { user, supabase } = await requireUser();
+
+  const { data: codevData, error: codevError } = await supabase
+    .from("codev")
+    .select("role_id")
+    .eq("id", user.id)
+    .single();
+
+  if (codevError || !codevData?.role_id) {
+    throw new Error("Forbidden");
+  }
+
+  // Admins bypass
+  if (codevData.role_id === 1) {
+    return { user, supabase, roleId: codevData.role_id };
+  }
+
+  const { data: roleData, error: roleError } = await supabase
+    .from("roles")
+    .select(permissionKey)
+    .eq("id", codevData.role_id)
+    .single();
+
+  if (roleError || !roleData || !(roleData as any)[permissionKey]) {
+    throw new Error("Forbidden");
+  }
+
+  return { user, supabase, roleId: codevData.role_id };
+}
+
+/**
+ * Ensures the caller is a member of the specified project.
+ */
+export async function requireProjectMember(projectId: string) {
+  const { user, supabase } = await requireUser();
+
+  const { data: codevData } = await supabase
+    .from("codev")
+    .select("role_id")
+    .eq("id", user.id)
+    .single();
+
+  // Admins bypass
+  if (codevData?.role_id === 1) {
+    return { user, supabase, roleId: codevData.role_id };
+  }
+
+  const { data: memberData, error: memberError } = await supabase
+    .from("project_members")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("codev_id", user.id)
+    .maybeSingle();
+
+  if (memberError || !memberData) {
+    throw new Error("Forbidden");
+  }
+
+  return { user, supabase, roleId: codevData?.role_id };
+}
+
+/**
+ * Helper specifically for self-mutating actions.
+ * Enforces that the caller is either mutating their own data, or has an optional fallback role (e.g., admin).
+ */
+export async function requireSelfOrRole(targetUserId: string, fallbackRoleKey?: RolePermissionKey) {
+  const { user, supabase } = await requireUser();
+
+  if (user.id === targetUserId) {
+    return { user, supabase };
+  }
+
+  // If not self, verify fallback role if provided
+  if (fallbackRoleKey) {
+    const { data: codevData } = await supabase
+      .from("codev")
+      .select("role_id")
+      .eq("id", user.id)
+      .single();
+
+    if (codevData?.role_id === 1) {
+      return { user, supabase, roleId: codevData.role_id };
+    }
+
+    if (codevData?.role_id) {
+      const { data: roleData } = await supabase
+        .from("roles")
+        .select(fallbackRoleKey)
+        .eq("id", codevData.role_id)
+        .single();
+
+      if (roleData && (roleData as any)[fallbackRoleKey]) {
+        return { user, supabase, roleId: codevData.role_id };
+      }
+    }
+  }
+
+  throw new Error("Forbidden");
+}

--- a/apps/codebility/supabase/migrations/20260523_add_approved_at_to_tasks.sql
+++ b/apps/codebility/supabase/migrations/20260523_add_approved_at_to_tasks.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tasks ADD COLUMN approved_at TIMESTAMPTZ;
+
+-- Backfill existing archived tasks with their updated_at time so old leaderboard data is not lost
+UPDATE tasks SET approved_at = updated_at WHERE is_archive = true AND approved_at IS NULL;


### PR DESCRIPTION
. Created Shared Helper: auth-guard.ts
Added lib/server/auth-guard.ts providing four robust security boundaries:

requireUser(): Rejects callers without a valid session.
requireRole(roleKey): Rejects callers without the specified role permission in the roles table.
requireProjectMember(projectId): Rejects callers who are not members of the target project.
requireSelfOrRole(targetUserId, fallbackRole): Enforces self-mutation (e.g. for dashboard actions), with an optional fallback role (like admin) that can mutate any user.

2. Hardened Dashboard Actions
Files Touched: app/home/(dashboard)/actions.ts
Actions Secured: updateUserSchedule, startUserTimer, stopUserTimer, logUserTime, updateUserTaskOnHand, updateUserAvailabilityStatus.
Change: Replaced createClientServerComponent() with requireSelfOrRole(codevId, "dashboard"). Now, users can only start timers and update schedules for their own account unless they possess a dashboard override role.

3. Hardened In-House Actions
Files Touched: app/home/in-house/actions.ts
Actions Secured: updateCodev, updateNdaUrls, sendNdaEmailAction, deleteCodevAction.
Change: Added requireRole("inhouse"). Only authenticated members with the inhouse permission can mutate the global codev directory and trigger NDA workflows.

4. Hardened Promote-Modal Actions
Files Touched: app/home/promote-modal/actions.ts
Actions Secured: upsertActiveModal, createModal, deleteModal, toggleModalActive, uploadModalImage.
Change: Added requireRole("settings") to prevent low-privilege users from changing promotional content on the platform.

5. Hardened Ticket-Support Actions
Files Touched: app/home/ticket-support/actions.ts
Actions Secured: submitTicket.
Change: Removed the trust in the client-supplied userId. Forced the server action to pull identity straight from requireUser().

6. Fixed Identity Lookups in My-Team Actions
Files Touched: app/home/my-team/actions.ts
Actions Secured: createChecklistItem, updateChecklistItem, deleteChecklistItem.
Change: Replaced .eq("email_address", user.email) queries with stable .eq("id", user.id) utilizing the secure requireUser() block.