### PR TITLE
fix(auth): repair password reset redirect and recovery callback

### DIFF
--- a/apps/codebility/app/auth/callback/route.ts
+++ b/apps/codebility/app/auth/callback/route.ts
@@ -16,7 +16,17 @@ export async function GET(request: Request) {
     const cookieStore = await cookies();
     const supabase = await createClientServerComponent();
 
-    await supabase.auth.verifyOtp({ token_hash: tokenHash, type: "email" });
+    // Recovery links carry a recovery token, so verify with the "recovery" OTP type.
+    const { error } = await supabase.auth.verifyOtp({
+      token_hash: tokenHash,
+      type: "recovery",
+    });
+
+    // Honor verification failures: send the user to a clear sign-in/error state
+    // instead of redirecting to the destination page unauthenticated.
+    if (error) {
+      return NextResponse.redirect(new URL("/auth/sign-in", origin));
+    }
 
     if (redirectTo) {
       return NextResponse.redirect(`${origin}${redirectTo}`);
@@ -51,7 +61,31 @@ export async function GET(request: Request) {
         throw new Error("User not found or not authenticated");
       }
 
-      // Update the codev table with the Applicant role ID and application status
+      // Determine whether this is a genuine first-time signup or an existing
+      // approved user delivered through the recovery/sign-in `code` path.
+      const { data: existingCodev } = await supabase
+        .from("codev")
+        .select("role_id, application_status")
+        .eq("id", user.id)
+        .single();
+
+      const isExistingApprovedUser =
+        !!existingCodev &&
+        ((existingCodev.role_id != null &&
+          existingCodev.role_id !== applicantRoleId) ||
+          (existingCodev.application_status != null &&
+            existingCodev.application_status !== "applying"));
+
+      if (isExistingApprovedUser) {
+        // Existing approved user: establish the session WITHOUT mutating
+        // role_id/application_status, and route to their normal destination.
+        await supabase.auth.exchangeCodeForSession(code);
+        return NextResponse.redirect(
+          new URL(redirectTo ?? "/home", requestUrl.origin),
+        );
+      }
+
+      // Genuine first-time signup: assign the Applicant role and status.
       const { error: updateError } = await supabase
         .from("codev")
         .update({

--- a/apps/codebility/app/auth/password-reset/action.ts
+++ b/apps/codebility/app/auth/password-reset/action.ts
@@ -28,7 +28,7 @@ export const resetUserPassword = async (email: string) => {
         }
 
         const url = data.availability_status === "passed" 
-            ? `${origin}/auth/callback?redirect_to=/home/settings/account-settings` 
+            ? `${origin}/auth/callback?redirect_to=/home/account-settings` 
             : `${origin}/auth/callback?redirect_to=/applicant/account-settings`;
 
         /* 


### PR DESCRIPTION
- Route passed Codevs to the ungated /home/account-settings so non-admins reach the change-password screen instead of being bounced to /home

- Verify the recovery token with type 'recovery' and redirect to sign-in when verification fails

- Guard the PKCE code branch so existing approved users are not demoted to the Applicant role/status