### PR TITLE
docs(tasks): add per-developer task specs

### DIFF
--- a/docs/tasks/Angelo-FS/Query-Performance-Data-Fetching-Hardening.md
+++ b/docs/tasks/Angelo-FS/Query-Performance-Data-Fetching-Hardening.md
@@ -1,0 +1,66 @@
+# Query Performance & Data-Fetching Hardening
+
+## Summary
+
+There are a few spots in `apps/codebility` where we fetch data inefficiently, and they'll only get worse as the `codev` table grows. A couple of `select("*")` queries with no limit, one place that pulls the whole table into the browser through a pagination loop, some data fetched client-side on every page load that could be server-rendered, and a couple of N+1 patterns. The goal is to clean up the data layer without changing anything the user sees.
+
+## Technical Context
+
+**Unbounded / over-fetching:**
+- `app/(marketing)/_components/landing/LandingAdmins.tsx:29-30` — `from("codev").select("*").eq("role_id", 1)` and `.eq("role_id", 5)`, no `.limit()`. Fetches all admins/mentors for a featured display.
+- `app/home/kanban/[projectId]/[id]/_components/tasks/_components/TaskComments.tsx` (`fetchUsers`, ~line 1154) — `from("codev").select(...).order("first_name")` with **no `.limit()`**; fetches the entire `codev` table for @mention suggestions, and is re-invoked on comment lifecycle/realtime events.
+- `store/codev-store.ts` (~line 42) — store hydrates via `select("*")` on `codev`.
+- Worth a look too: `DashboardWeeklyTop.tsx` `attendance_points` select-all, `FilterCodevs.tsx` positions/projects select-all, and the profile page's work_experience/education with no limit.
+
+**Client-side fetch that should be server-side / cached:**
+- `app/home/my-team/AddMembersModal.tsx:387-435` — a `while (true)` loop with `PAGE_SIZE = 1000` paginating the full `codev` table **in the browser**. Should be a server action returning a filtered, bounded result.
+- Same idea for `FilterCodevs.tsx` and `NewsBanner.tsx`, which fetch in `useEffect` on every load — good candidates for server components or cached fetches.
+
+**N+1 / sequential:**
+- `kanban/[projectId]/[id]/actions.ts` `updateDeveloperLevels` (~lines 33-52) — one query per skill category in a `.map`; batch with a single `.in("skill_category_id", [...])`.
+- `TaskComments.tsx` author hydration is already batched with `.in("id", authorIds)` but is re-run frequently — cache it.
+
+A few of these I've confirmed in the code (the `LandingAdmins`, `TaskComments` mention fetch, and `AddMembersModal` loop); the "worth a look" ones I haven't double-checked recently, so confirm them against current source before touching.
+
+## Objectives
+
+- Add sensible bounds (`.limit()` + pagination/`.in()` where appropriate) to all unbounded `select("*")` / list queries, especially on `codev`.
+- Move the client-side full-table pagination in `AddMembersModal` to a **server action** that returns filtered, bounded results.
+- Convert per-page-load client fetches (filter data, news banners) to server components or cached fetches (React Query/SWR with sensible stale time, or RSC).
+- Replace the unbounded @mention user fetch with a bounded query + client-side filtering (or server-side mention search), and cache it so it isn't re-fetched on every realtime event.
+- Batch the confirmed N+1 queries.
+
+## Sprint Plan (1 fortnightly sprint)
+
+- **Week 1:** Bound all unbounded queries (limits/pagination), fix the @mention fetch + caching, and batch the `updateDeveloperLevels` N+1. Lowest-risk, immediate wins.
+- **Week 2:** Move `AddMembersModal` member loading to a server action; convert filter-data and news-banner client fetches to server-rendered/cached. Verify no behavior change and measure before/after query counts.
+
+## Expected Behavior
+
+- No screen fetches an entire large table to the browser; lists are bounded and/or paginated.
+- @mention suggestions and member pickers load from bounded queries and don't re-fetch the whole table on every interaction/realtime event.
+- Product behavior (what the user sees and can do) is unchanged; only performance improves.
+
+## Acceptance Criteria
+
+- No remaining unbounded `select("*")`/list query on `codev` (or other large tables) without a `.limit()` or pagination — check with a grep and a quick review.
+- `AddMembersModal` no longer runs a browser-side `while(true)` pagination loop; member data comes from a bounded server action.
+- Filter data and news banners are no longer fetched client-side on every page load (server-rendered or cached).
+- The confirmed N+1 in `updateDeveloperLevels` is collapsed to a single batched query.
+- Before/after notes in the PR show reduced query counts / payload sizes for at least the @mention and member-loading paths.
+- No functional regressions.
+
+## Reminders
+
+- Coordinate with the auth-hardening task (Jury) on the new member-loading server action so it's built once, with auth, and reused.
+- Perform comprehensive testing before PR; include before/after measurements.
+
+## Instructions
+
+- Branch: `query-performance-hardening/angelo`. One PR per phase is recommended.
+- Comprehensive PR description documenting each query changed and why. Request team-lead review. Maintain Kanban status.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.
+</content>

--- a/docs/tasks/Angelo-FS/RLS-Disabled-Public-Table-Security-Fix.md
+++ b/docs/tasks/Angelo-FS/RLS-Disabled-Public-Table-Security-Fix.md
@@ -1,0 +1,82 @@
+# Critical — RLS Disabled on Public Table (Security Fix)
+
+## Summary
+
+Supabase flagged a **CRITICAL security advisory** on the **Codebility Portal** project (`hibnlysaokybrsufrdwp`):
+
+> **Table publicly accessible** — *"Anyone with your project URL can read, edit, and delete all data in this table because Row-Level Security is not enabled."*
+> Lint: **`rls_disabled_in_public`** · Advisory dated **08 Jun 2026**.
+
+A table in the `public` schema has **Row-Level Security (RLS) disabled**. Because the project's anon/public API key is exposed to the browser (it's a `NEXT_PUBLIC_*` value, as it must be), **anyone who has the project URL + anon key can directly hit PostgREST and read, modify, or delete every row in that table** — bypassing the app, middleware, and server actions entirely. This is a live data-exposure risk and needs to be fixed promptly.
+
+The team already did an RLS hardening pass in Feb 2026 (`20260219_rls_*` migrations), so this is most likely a table that was **added afterward** (or otherwise missed) and never had RLS turned on. The fix is to identify the exact table(s), enable RLS, and add correct policies via a new migration — **without breaking legitimate app access.**
+
+## Technical Context
+
+- The advisory email does **not** name the specific table — the authoritative source is the **Supabase Dashboard → Advisors → Security** (and/or the Database Linter), which lists every `rls_disabled_in_public` finding with the exact table name(s). **Start there.** There may be more than one table.
+- Existing RLS convention lives in `apps/codebility/supabase/migrations/` — notably:
+  - `20260219_rls_critical_fixes.sql`, `20260219_rls_critical_fixes_v2.sql`, `20260219_rls_hotfix.sql` — the house pattern for enabling RLS + writing policies.
+  - Pattern used: `ALTER TABLE x ENABLE ROW LEVEL SECURITY;` then `CREATE POLICY ... ON x FOR <op> TO public USING (...) WITH CHECK (...)`, with admin checks like `auth.uid() IN (SELECT id FROM admin_users)` and ownership checks like `codev_id = auth.uid()`.
+- Tables created **after** the Feb 2026 pass are the prime suspects — e.g. those from `20260219_create_client_outreach_tracker.sql`, `20260309_create_ticket_support_table.sql`, `create_onboarding_videos_table.sql`, and any table added directly in the Supabase dashboard (dashboard-created tables don't go through these migration files, so they're easy to miss). **Confirm the real culprit via the Advisor — do not assume.**
+- ⚠️ **Critical gotcha:** Enabling RLS with **no policies = default deny**. The moment you run `ALTER TABLE x ENABLE ROW LEVEL SECURITY;`, all access through the anon/auth API is blocked until you add policies. If the app reads/writes that table via the client (not just the service-role key), turning on RLS **without** the right policies will break those features. You must enable RLS **and** add matching policies in the **same migration**.
+- Related background: this codebase has a known pattern of **server actions that don't always enforce auth** — so RLS is the real backstop, not the app layer. Do not rely on "the server action checks it" as justification to leave a policy wide open.
+
+## Head-start: likely candidate tables (from repo analysis)
+
+A cross-reference of every `CREATE TABLE` vs `ENABLE ROW LEVEL SECURITY` in `apps/codebility/supabase/migrations/` found **three migration-tracked tables created but never RLS-enabled** — the most likely culprits to check first:
+
+| Table | Created in | Notes |
+|-------|-----------|-------|
+| **`project_categories`** | `20251127_project_category_many_to_many.sql` | This whole migration enabled RLS on **nothing** — strongest suspect. |
+| **`projects_category`** | `20251127_project_category_many_to_many.sql` | Same migration; same gap. |
+| **`notification_templates`** | `create_notification_system.sql` | Its siblings (`notifications`, `notification_preferences`, `notification_queue`) were RLS-enabled at lines 447-449 — this one was skipped. |
+
+**Caveat (read this):** this analysis only sees tables created *through these migration files*. The **core tables — `codev`, `roles`, `project`, `project_members`, `applicant`, `job_listings`, `kanban_*`, `task`, etc. — are NOT created in any migration in this repo** (they predate the migration setup or were made directly in the dashboard), so their RLS status **cannot be confirmed from the codebase**. If the advisory names one of those instead, it's more sensitive (user data) and the dashboard is the only source of truth. **Always confirm the actual flagged table(s) in Supabase Advisors → Security before writing the migration — this list is a head-start, not the answer.**
+
+## Objectives
+
+1. **Identify** every table flagged by `rls_disabled_in_public` via Supabase **Advisors → Security** (record the full list — there may be more than one).
+2. For each flagged table, determine **who legitimately needs access** and how the app uses it:
+   - Is it read/written by the **browser client** (anon/authenticated key) or only by **server-side service-role** code? Grep the codebase for the table name to find every access site.
+   - Is the data **per-user** (owner-scoped), **admin-only**, **public-read**, or **system-only**?
+3. **Enable RLS and add correct policies** in a single new migration, following the existing `20260219_rls_*` house style:
+   - `ALTER TABLE <table> ENABLE ROW LEVEL SECURITY;`
+   - Add the **minimum** policies needed: owner-scoped (`USING (codev_id = auth.uid())`), admin (`auth.uid() IN (SELECT id FROM admin_users)`), public-read where genuinely intended, etc.
+   - Add **`WITH CHECK`** clauses on INSERT/UPDATE to prevent privilege escalation / row spoofing.
+   - **Do not** add a blanket `TO public USING (true)` unless public read is genuinely intended and reviewed.
+4. **Verify** the advisory clears **and** the app still works for the real access paths (no features break from default-deny).
+
+## Expected Behavior
+
+- The flagged table(s) have RLS **enabled** with policies that allow exactly the legitimate access and nothing more.
+- A direct PostgREST/anon-key request to that table (outside the app) can no longer read/modify/delete arbitrary rows — it's constrained by policy (or denied).
+- All existing app features that use the table continue to function for properly authenticated users.
+- The Supabase **Security Advisor** no longer reports `rls_disabled_in_public` for the table(s).
+
+## Acceptance Criteria
+
+- A new migration in `apps/codebility/supabase/migrations/` (naming: `YYYYMMDD_<description>.sql`, e.g. `20260610_enable_rls_<table>.sql`) enables RLS and adds policies for **every** flagged table.
+- Each table's policies are **least-privilege**: owner/admin/system scoped as appropriate, with `WITH CHECK` on writes. No unjustified `USING (true)`.
+- **Supabase Dashboard → Advisors → Security shows the `rls_disabled_in_public` finding resolved** (screenshot before/after in the PR).
+- Manual verification that the app's real access paths still work (list the features tested in the PR — e.g. the page/action that reads/writes each table).
+- A direct anon-key query against the table (e.g. via `curl`/Supabase REST) is now denied or correctly scoped — include the check in the PR description.
+- Migration is idempotent-safe where practical (`DROP POLICY IF EXISTS` before `CREATE POLICY`, matching the existing files).
+
+## Reminders
+
+- **Confirm the exact table(s) from the Advisor first — do not guess from this doc.** There may be more than one finding.
+- Enabling RLS is **default-deny**: always ship RLS + policies **together** in the same migration, or you'll break the app.
+- Grep the codebase for each table name to find every read/write site before deciding policies — missing one means a broken feature after deploy.
+- Don't loosen policies just to make something work — if a feature legitimately needs broad access, it should use the **service-role key server-side**, not a wide-open public policy.
+- Apply the migration to the project via the normal flow and re-run the Advisor to confirm it clears. Coordinate with the team lead on applying it to production (`hibnlysaokybrsufrdwp`).
+- This is a security fix — treat it as higher priority than feature work.
+
+## Instructions
+
+- Branch naming: `rls-public-table-fix/your-name`. Commit all changes to this branch before opening the PR.
+- Include in the PR description: the list of flagged tables, the access analysis (who/how each is used), the policy rationale, before/after Advisor screenshots, and the anon-key denial check.
+- Request review from your team lead before applying to production. Maintain Kanban card status as work progresses.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.

--- a/docs/tasks/Jury-FS/Password-Reset-Email-Redirects-To-Home.md
+++ b/docs/tasks/Jury-FS/Password-Reset-Email-Redirects-To-Home.md
@@ -1,0 +1,54 @@
+# Fix Password Reset Email Link Redirecting to /home
+
+## Summary
+
+When a user requests a password reset and clicks the link in the email, they get bounced to the `/home` dashboard instead of landing on the Account Settings page where the Change Password form lives. The destination the reset link points to is protected by an admin-only role permission, so any regular Codev whose role doesn't have that permission is redirected away and can never finish changing their password.
+
+## Background
+
+The reset flow targets `/home/settings/account-settings`. The password-reset action builds the link, the auth callback verifies the email token and forwards the user to that path, and then the middleware blocks it.
+
+In `apps/codebility/app/auth/password-reset/action.ts`, a "passed" user gets a link to `/auth/callback?redirect_to=/home/settings/account-settings`. The middleware in `apps/codebility/middleware.ts` maps the `/home/settings` prefix to the `settings` permission, and `/home/settings/account-settings` falls under that prefix. Roles without the `settings` permission hit the redirect to `/home`, so they never reach the form.
+
+Account Settings is a personal page — changing your own password, 2FA, and account deletion — so it shouldn't require the admin `settings` permission at all. The same page already exists at the ungated path `/home/account-settings` (it re-exports the same component), and that path is not in the middleware permission map, so it's reachable by any signed-in user.
+
+## Objectives
+
+- Make the password reset email link land every user on a working Change Password screen, regardless of their role permissions.
+- Stop a successful password reset from having any side effect on the user's role or application status.
+- Make a failed or expired reset token end in a clear sign-in/error state rather than a misleading dashboard redirect.
+
+## Expected Behavior
+
+- Clicking the reset link signs the recovery session in and opens the Account Settings page with the Change Password card visible and usable, for any role.
+- No user is silently demoted or has their application status changed as a side effect of resetting their password.
+- An invalid or expired link sends the user to sign-in with a clear message, not to `/home`.
+
+## Acceptance Criteria
+
+- [ ] A regular Codev (role without the `settings` permission) can click the reset email and reach the Change Password form.
+- [ ] An admin can still reach the same form through the reset email.
+- [ ] An applicant (non-passed user) reaches their account-settings page from the reset email.
+- [ ] After a reset, the user's `role_id` and `application_status` are unchanged in the `codev` table.
+- [ ] An expired/invalid reset link does not land the user on `/home`; it shows an error or returns them to sign-in.
+
+## Solution Hint
+
+Treat these as advisory, not prescriptive.
+
+- Primary fix: in `apps/codebility/app/auth/password-reset/action.ts`, change the "passed" redirect target from `/home/settings/account-settings` to `/home/account-settings` (the ungated page that renders the same Account Settings component).
+- Alternative if the nested URL must stay: allow `/home/settings/account-settings` past the `settings` permission check in `apps/codebility/middleware.ts` before the role-permission block runs.
+- While in `apps/codebility/app/auth/callback/route.ts`, two related problems live in the same flow and are worth fixing in this pass:
+  - The recovery token is verified with `verifyOtp({ type: "email" })`, but a recovery token's type is `"recovery"`. The call's error is never checked and the route redirects regardless of whether a session was actually established.
+  - If the recovery arrives as a `code` (PKCE) param instead of `token_hash`, the callback runs its signup branch, which sets `role_id` to the Applicant role and `application_status` to `applying`, then sends the user to `/applicant/waiting`. That branch must not run for a password reset — it would demote an existing passed user. Distinguish recovery/sign-in from first-time signup before touching `role_id`/`application_status`.
+
+## Reminders
+
+- Test with two accounts: one regular Codev without the `settings` permission and one admin, plus one applicant. Confirm all three reach a change-password screen from the email.
+- After resetting, check the `codev` row to confirm `role_id` and `application_status` didn't change.
+- Test an expired/used link to confirm the error path.
+
+## Instructions
+
+- Branch off `dev`, e.g. `fix/password-reset-email-redirect`.
+- Open the PR against `dev` with a short, factual description of the root cause and the fix.

--- a/docs/tasks/Jury-FS/Server-Action-Auth-Hardening-Week2-ProjectScoped.md
+++ b/docs/tasks/Jury-FS/Server-Action-Auth-Hardening-Week2-ProjectScoped.md
@@ -1,0 +1,65 @@
+# Server-Action Auth Hardening — Week 2: Project-Scoped & Community Actions
+
+## Summary
+
+Week 1 of the auth-hardening work shipped: the `auth-guard.ts` helper landed and the identity/admin surface (dashboard, in-house, promote-modal, ticket-support, my-team checklist, appointments) now checks the caller before mutating. The project-scoped and community surface was never done. Five files still mutate the database with no authorization at all — roughly 49 mutating actions that any logged-in user can call directly through the action endpoint, skipping every UI and page-middleware gate. This task closes that remaining half.
+
+This is high risk because these same tables have no database backstop either: RLS is still disabled on the relevant tables, so there is currently no protection at either layer.
+
+## Background
+
+Confirmed current state on `dev`:
+
+- `kanban/[projectId]/[id]/actions.ts` — ~23 mutations (tasks, columns, drafts). Some functions call `getUser()` but only *after* the mutation, for notifications — so it authenticates nothing. This is the single biggest exposure, and it's also why the Move-to-Sprint feature (PR #594) merged without server-side auth.
+- `overflow/actions.ts` — ~16 mutations (posts, comments, likes) with no auth and no ownership checks on edit/delete.
+- `my-team/[projectId]/actions.ts` — ~5 mutations (attendance, meetings); also trusts a client-supplied `created_by`.
+- `kanban/[projectId]/actions.ts` — ~4 mutations (create/edit sprint).
+- `kanban/actions.ts` — 1 mutation (create board).
+
+The helper to use already exists: `lib/server/auth-guard.ts` exports `requireUser()`, `requireRole(permissionKey)`, `requireProjectMember(projectId)`, and `requireSelfOrRole(...)`. Week 1 files are the worked examples of the correct call pattern.
+
+## Objectives
+
+- Apply an authorization check to every mutating action in the five files above, using the existing `auth-guard.ts` helper — never UI state, name strings, hardcoded emails, or client-supplied identity fields.
+- For project-scoped actions (all kanban files, my-team attendance/meetings), gate on `requireProjectMember(projectId)` in addition to authentication, matching the permission the middleware enforces for the corresponding page.
+- In `kanban/[projectId]/[id]/actions.ts`, move the existing `getUser()` calls to the top of each action so the check happens *before* the mutation, not after.
+- For `overflow` post/comment edit and delete, enforce ownership (the caller must own the row) — or an admin/appropriate role.
+- Stop trusting client-supplied identity in `my-team/[projectId]` (`created_by`) — derive it from `user.id`.
+- Return clear, non-leaking `Unauthorized` / `Forbidden` errors and perform no write on rejection.
+
+## Expected Behavior
+
+- Invoking any of these actions without a valid session returns `Unauthorized` and writes nothing.
+- A user who is not a member of the target project (or not the owner, for overflow edits/deletes) receives `Forbidden` and writes nothing.
+- Legitimate members with the right role/membership see no functional change.
+- Identity and `created_by` are always resolved from `user.id`, never from client input.
+
+## Acceptance Criteria
+
+- [ ] Every mutating action in `kanban/[projectId]/[id]/actions.ts`, `kanban/[projectId]/actions.ts`, `kanban/actions.ts`, `my-team/[projectId]/actions.ts`, and `overflow/actions.ts` performs an auth (and where applicable membership/ownership) check **before** any mutation.
+- [ ] The kanban `[id]` actions no longer call `getUser()` only after mutating — the check is up front.
+- [ ] Project-scoped actions verify `project_members` membership via `requireProjectMember`.
+- [ ] Overflow edit/delete actions enforce row ownership (or admin).
+- [ ] `my-team/[projectId]` derives `created_by` from `user.id`, not client input.
+- [ ] Manual verification: a low-privilege / non-member session is rejected on a cross-project task edit, an overflow post delete it doesn't own, and an attendance write for a project it's not on; the same actions succeed for an authorized member.
+- [ ] Final sweep: grep the remaining `"use server"` files for `.insert/.update/.delete/.upsert/.rpc` and confirm no unguarded mutation remains anywhere.
+
+## Solution Hint
+
+Treat these as advisory, not prescriptive.
+
+- Reuse `lib/server/auth-guard.ts` exactly as the Week 1 files do — don't re-implement checks. For a project-scoped action that already receives `projectId`, `await requireProjectMember(projectId)` at the top is usually enough; for board/sprint creation, gate on the kanban permission via `requireRole("kanban")` plus membership where a project context exists.
+- In the kanban `[id]` file, the fix for the notification-only `getUser()` calls is to hoist the auth to the first line of each action and reuse that user for both the check and the later notification.
+- For overflow ownership, compare the row's author id to `user.id` before update/delete; allow an admin role to override if that matches current product behavior.
+- Consider splitting into two PRs (kanban vs overflow+attendance) to keep the review manageable, as the original task suggested.
+
+## Reminders
+
+- Pairs with Kris's RLS task — keep the role/membership semantics aligned with the DB policies, but don't block on it; the app-layer guard must stand on its own.
+- Test rejection explicitly and note in the PR how you verified an unauthorized call is blocked.
+- Don't regress legitimate flows — kanban board/task/sprint/draft operations, attendance, meetings, and overflow posting should all still work for authorized members.
+
+## Instructions
+
+- Branch: `server-action-auth-hardening-week2/jury`. Splitting into two PRs is fine.
+- PR description: list each action changed and the guard applied, plus the rejection test you ran.

--- a/docs/tasks/Jury-FS/Server-Action-Authorization-Hardening.md
+++ b/docs/tasks/Jury-FS/Server-Action-Authorization-Hardening.md
@@ -1,0 +1,79 @@
+# Server-Action Authorization Hardening
+
+## Summary
+
+We have a lot of server actions in `apps/codebility` that mutate data without checking who's calling them — somewhere north of 35 functions across 9 files. They rely on the UI hiding controls by role and on the route middleware, but neither actually protects a server action: any logged-in user can call the action directly (through its RPC endpoint or a plain `fetch`) and skip every UI gate. The middleware in `middleware.ts` only runs on page navigation, not on action calls. This task adds a real authorization check to each of these actions.
+
+This is a real, exploitable surface. For example, the dashboard actions take a `codevId` parameter and update the `codev` table by id with no check that the caller *is* that user — so any session can edit or delete another user's schedule, timers, availability, or NDA status. The `codev` table also has **RLS disabled** (see migration `20260219_critical_security_fixes.sql:199`), so there is currently *no* backstop for those mutations at all.
+
+The goal is to add a consistent authorization layer to every mutating server action, gating on the caller's identity (`auth.getUser()`) and `role_id` / project membership — never on UI state, name strings, or hardcoded emails. PR #596 (the founder-backdoor fix, merge `4d1949ff`) is the **worked example** of the correct fix shape.
+
+## Technical Context
+
+- The recurring anti-patterns (see related portal-wide notes): **(1)** no `getUser()` at all; **(2)** auth gated on a brittle signal (name string / hardcoded email) instead of `role_id`; **(3)** user-controlled values interpolated into PostgREST `.or()` grammar.
+- **Correct pattern** (from PR #596): at the top of each action, before any data lookup —
+  1. `const { data: { user } } = await supabase.auth.getUser();` → reject if absent.
+  2. Look up caller's `codev.role_id` via `.eq("id", user.id)` (NOT `.or()` interpolation, NOT email).
+  3. Verify the required permission against the `roles` table, matching the gate the middleware applies to the corresponding page (`routePermissionMap` in `middleware.ts`).
+  4. For project-scoped mutations (kanban, attendance, meetings), additionally verify membership via `project_members`.
+- **Deliverable foundation:** create a reusable helper (e.g. `lib/server/auth-guard.ts` exporting `requireUser()`, `requireRole(roleId)`, `requireProjectMember(projectId)`) so every action calls one well-tested guard instead of re-implementing checks. Land this helper first.
+
+### Actions that need a guard
+
+- `app/home/(dashboard)/actions.ts` — `updateUserSchedule`, `startUserTimer`, `stopUserTimer`, `logUserTime`, `updateUserTaskOnHand`, `updateUserAvailabilityStatus`
+- `app/home/in-house/actions.ts` — `updateCodev`, `updateNdaUrls`, `sendNdaEmailAction`, `deleteCodevAction`
+- `app/home/admin-controls/appointments/actions.ts` — `updateAppointmentStatus`
+- `app/home/promote-modal/actions.ts` — `upsertActiveModal`, `createModal`, `deleteModal`, `toggleModalActive`
+- `app/home/ticket-support/actions.ts` — `submitTicket` (also: stop trusting client-supplied `userId`)
+- `app/home/my-team/actions.ts` — `createChecklistItem`, `updateChecklistItem`, `deleteChecklistItem` (Flavor 2: replace `.eq("email_address", user.email)` lookups with `.eq("id", user.id)`)
+- `app/home/kanban/[projectId]/[id]/actions.ts` — `updateTaskColumnId`, `createNewTask`, `updateTask`, `deleteTask`, `createNewColumn`, `updateColumnPosition`, `completeTask`, `batchUpdateTasks`, `updateTaskPRLink`, `unarchiveTask`, `saveDraft`, `deleteDraft`, `promoteDraft` (several call `getUser()` *after* mutating, only for notifications — move the check before the mutation)
+- `app/home/kanban/[projectId]/actions.ts` — `createNewSprint`, `EditSprint` · `app/home/kanban/actions.ts` — `createNewBoard`
+- `app/home/my-team/[projectId]/actions.ts` — `saveAttendance`, `bulkSaveAttendance`, `saveMeetingSchedule`, `createMeeting` (stop trusting client `created_by`)
+- `app/home/overflow/actions.ts` — `postQuestion`, `updateQuestion`, `deletePostAndImages`, `postComment`, `markAsSolution`, `updateComment`, `deleteComment`, `togglePostLike`, `toggleCommentLike` (ownership checks for edit/delete)
+
+This is the list we know about. Before wrapping up, grep the rest of the `"use server"` files for mutations (`.insert/.update/.delete/.upsert/.rpc`) and make sure each one is guarded too — there are probably a few more.
+
+## Objectives
+
+- Implement a shared, tested authorization helper and apply it to **every** mutating server action in `apps/codebility`.
+- Gate each action on `auth.getUser()` + `role_id` (and `project_members` membership where project-scoped), matching the permission the middleware enforces for the corresponding page.
+- Replace email-based / name-based identity lookups with `user.id`-based lookups.
+- Ensure no user-controlled value is interpolated into PostgREST `.or()`/`.filter()` grammar; use parameterized `.eq()` lookups.
+- Return clear, non-leaking errors (`Unauthorized` / `Forbidden`) without exposing internal details.
+
+## Sprint Plan (1 fortnightly sprint)
+
+- **Week 1:** Land the `auth-guard` helper. Harden the user/identity & admin surface — `(dashboard)`, `in-house`, `appointments`, `promote-modal`, `ticket-support`, and the `my-team` checklist identity fix. These touch the RLS-disabled `codev` table and are the highest risk.
+- **Week 2:** Harden the project-scoped & community surface — all `kanban/**` actions (tasks, columns, drafts, sprints, boards) with `project_members` checks, `my-team/[projectId]` attendance/meetings, and `overflow` post/comment ownership. Final sweep grep to confirm zero unguarded mutations remain.
+
+## Expected Behavior
+
+- Invoking any mutating server action without a valid session returns `Unauthorized` and performs no DB write.
+- A user without the required role/permission (or who is not a member of the target project) receives `Forbidden` and performs no write.
+- Legitimate users with the correct role/membership experience no functional change.
+- Identity is always resolved from `user.id`, never email or name.
+
+## Acceptance Criteria
+
+- A reusable auth-guard utility exists, is unit-testable, and is used by every mutating server action.
+- Every action in the confirmed inventory (and any others found during the sweep) performs an auth + (where applicable) permission/membership check **before** any mutation.
+- No mutating server action gates authorization on a name string, hardcoded email, or client-supplied identity field (`userId`, `created_by`, etc.).
+- No PostgREST `.or()`/`.filter()` call interpolates an unescaped user-controlled value.
+- Manual verification: attempting a cross-user / cross-project mutation with a low-privilege session is rejected; the same action succeeds for an authorized user.
+- No regressions to legitimate flows (kanban, dashboard, my-team, appointments, overflow, in-house).
+
+## Reminders
+
+- This pairs with the RLS task (Kris). Coordinate so the role/permission semantics match between the app guard and the DB policies, but do not block on it — app-layer guards must stand on their own.
+- Perform comprehensive testing before PR. Include a short note in the PR describing how you verified rejection of an unauthorized call.
+
+## Instructions
+
+- Branch: `server-action-authorization-hardening/jury`. Consider splitting into a couple of PRs (one per phase) to keep reviews manageable.
+- Include a comprehensive PR description documenting each action changed and the guard applied.
+- Request review from your team lead. Maintain Kanban card status as work progresses.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.
+</content>

--- a/docs/tasks/Kris-BE/Row-Level-Security-Completion.md
+++ b/docs/tasks/Kris-BE/Row-Level-Security-Completion.md
@@ -1,0 +1,60 @@
+# Row-Level Security (RLS) Completion & Audit
+
+## Summary
+
+The Supabase database has **partial, explicitly-incomplete** Row-Level Security. A set of Feb-2026 migrations (`supabase/migrations/20260219_*`) added policies for some tables (`attendance`, `ticket_support`, task *comments*, `profile_points`, `attendance_points`, `notification_queue`), but the work was deliberately scoped "without making assumptions about column names" and left TODOs. Critically, the `codev` table has **RLS disabled** — `20260219_critical_security_fixes.sql:199` raises `'WARNING: codev table RLS is DISABLED - should enable RLS on codev table'`.
+
+That leaves several sensitive tables with no access control at the DB layer: `codev`, `tasks`/kanban boards/columns/sprints, `appointments`, and `project_members`, among others. And since a lot of the server actions don't check auth either (that's Jury's task), these tables are effectively open to any logged-in session right now. This task closes the DB-layer gap: enable RLS on the uncovered tables, write the policies, finish the existing TODOs, and produce a coverage map so we know where we stand.
+
+## Technical Context
+
+- Existing RLS migrations to read first: `20260219_critical_security_fixes.sql`, `20260219_rls_critical_fixes.sql`, `20260219_rls_critical_fixes_v2.sql`, `20260219_rls_hotfix*.sql`, `20260219_rls_remove_duplicates.sql`, `fix_notification_rls_policies.sql`, and the `RLS_POLICY_TEMPLATES.md` reference.
+- **Known gaps / TODOs to resolve:** `20260219_rls_critical_fixes_v2.sql` has TODOs (~lines 365, 369) for owner-based UPDATE/DELETE and restricting task access to participants "when column names are confirmed" — confirm the actual schema (`database-schema.md`) and complete them.
+- **Role semantics:** Admin = `role_id` 1 (confirmed). Policies should align with the same permission model the app uses (`roles` table + `project_members` for project-scoped tables) so DB policies and the app-layer guards (Jury's task) agree. Coordinate on the exact membership/role predicates.
+- Migrations follow `apps/codebility/supabase/migrations/YYYYMMDD_description.sql`.
+
+## Objectives
+
+- **Enable RLS on the `codev` table** and write policies: a user may read/update their own row; admins (`role_id` 1) may manage all; restrict sensitive columns appropriately. (Note: `20260219_critical_security_fixes.sql:205` already defines an update policy but RLS is not enabled — enabling it is the missing step; reconcile with that policy.)
+- Enable RLS and add correct policies for the other uncovered sensitive tables: `tasks`, `kanban_board`/`kanban_column`/`kanban_sprint`, `appointments`, `project_members` (and any others surfaced by the audit). Project-scoped tables gate on `project_members` membership + role.
+- Resolve the outstanding TODOs in the `20260219_*` migrations (owner/participant-based UPDATE/DELETE).
+- Remove duplicate/conflicting policies (there is already a `rls_remove_duplicates` migration — extend that hygiene).
+- Produce an **RLS coverage matrix** (doc or migration comment) listing every table, whether RLS is enabled, and which policies apply for SELECT/INSERT/UPDATE/DELETE.
+
+## Sprint Plan (1 fortnightly sprint)
+
+- **Week 1:** Audit all tables for current RLS status (enabled? policies?) and produce the coverage matrix. Enable RLS + policies for `codev` (highest risk) and `appointments`. Test against real roles (admin, member, non-member) using the Supabase SQL editor / a test session.
+- **Week 2:** Enable RLS + policies for the kanban tables and `project_members`; resolve the v2 migration TODOs; dedupe conflicting policies. Re-run the full coverage matrix to confirm no sensitive table is left open.
+
+## Expected Behavior
+
+- With RLS enabled, a direct query/mutation (e.g. via the anon/authenticated Supabase client) that a user is not authorized for is **rejected at the database**, regardless of what the application layer does.
+- Users can read/modify only their own `codev` data unless they are admins.
+- Project-scoped rows (tasks, sprints, attendance, etc.) are only accessible to members of that project (and admins).
+- Legitimate app flows continue to work because the policies match the app's role/membership model.
+
+## Acceptance Criteria
+
+- RLS is **enabled** on `codev` and all previously-uncovered sensitive tables (`tasks`, kanban boards/columns/sprints, `appointments`, `project_members`).
+- Each such table has explicit, correct policies for SELECT/INSERT/UPDATE/DELETE matching the `roles` + `project_members` model.
+- The TODOs in the `20260219_*` RLS migrations are resolved (no placeholder "add later" gaps for owner/participant access).
+- No duplicate or contradictory policies remain.
+- An RLS coverage matrix is delivered covering every table.
+- Verified: with a low-privilege test session, direct cross-user / cross-project reads and writes are blocked by the DB; an authorized session succeeds. App flows (kanban, dashboard, my-team, appointments) still work end-to-end.
+- All changes are delivered as properly-named migrations under `supabase/migrations/`.
+
+## Reminders
+
+- Coordinate role/membership predicates with the app-layer auth task (Jury) so the two layers agree.
+- Test policies carefully before shipping — an over-tight policy can break legitimate flows; an over-loose one defeats the purpose. Verify with multiple role/session types.
+- Do not weaken existing working policies (attendance, ticket_support, comments) — only extend coverage.
+
+## Instructions
+
+- Branch: `rls-completion-audit/kris`. Deliver changes as migrations; one PR per phase is recommended.
+- Comprehensive PR description listing each table, the RLS state change, and the policies added. Request team-lead review. Maintain Kanban status.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.
+</content>

--- a/docs/tasks/Raineer-FE/Home-Page-Loader-Enhancement.md
+++ b/docs/tasks/Raineer-FE/Home-Page-Loader-Enhancement.md
@@ -1,0 +1,59 @@
+# Home Page Loader — Status Bar Repositioning
+
+**Assigned to:** Raineer Dela Rita (`delaritaraineer81`) · **Branch:** `home-page-loader-enhancement/raineer`
+
+## Summary
+
+The home page loading animation (`PageLoadingAnimation`) displays a hexagonal "polygon" with the Codebility logo spinning at its center, accompanied by a **loading status group** — a typewriter status line ("Initializing quantum framework…"), a holographic **progress bar**, and the CPU/GPU/RAM status indicators.
+
+Currently, this status group does not sit cleanly **below** the polygon. Instead it visually drifts to the **lower-right** of the hexagon (see reference screenshot `c:\dev\sc2.png`), so the progress bar and text appear off-center and detached from the logo rather than centered directly beneath it.
+
+This task repositions the loading status group so it is **centered directly below the polygon**, giving the loader a balanced, vertically-stacked appearance (polygon on top, status text + progress bar + indicators centered underneath).
+
+## Technical Context
+
+- **Component:** `apps/codebility/app/home/_components/PageLoadingAnimation.tsx`
+- **Likely root cause:** the status group (the `motion.div` around **line 248**) is positioned `absolute -bottom-20 left-1/2 -translate-x-1/2` **relative to the hexagon container**, which is only ~128px wide (`w-32`, line 117). Its contents are much wider than that anchor:
+  - the typewriter line uses `whitespace-nowrap` ("Initializing quantum framework…", line ~263),
+  - the progress bar is `w-48 sm:w-56 md:w-64` (192–256px, line ~268).
+  Because these overflow the narrow 128px anchor, they spill **rightward** instead of centering — which is why the group reads as "lower-right of the polygon."
+- **Suggested direction:** stop anchoring the status group to the narrow hexagon box. Either (a) restructure the loader's main container into a vertical `flex flex-col items-center` stack so the polygon and the status group are siblings that naturally center, with normal vertical spacing between them; or (b) keep absolute positioning but anchor it to the **full-size outer container** (`absolute inset-0 …`, line 32) with a properly centered, fixed-width wrapper. Approach (a) is cleaner and avoids the overflow math.
+
+## Objectives
+
+- Position the loading status group (typewriter text, progress bar, status indicators) so it is **horizontally centered directly below the polygon**.
+- Ensure the polygon and the status group form a clean **vertical stack** with consistent spacing, rather than the status group overlapping or drifting beside the polygon.
+- Preserve all existing visual elements and animations — the hexagon ring, triple-ring spinner, glitch/rotating logo, particles, scan line, matrix rain, corner accents, the typewriter effect, the animated progress bar, and the CPU/GPU/RAM indicators should all remain.
+- Keep the layout responsive: the centered-below arrangement must hold on mobile, tablet, and desktop without overflow, horizontal scroll, or the status group colliding with the polygon.
+
+## Expected Behavior
+
+- On any screen size, the loader shows the polygon (logo inside) centered, with the status text, progress bar, and indicators centered **immediately below it**.
+- The progress bar and typewriter text are visually centered under the polygon — not offset to one side.
+- No content overflows the viewport horizontally; the loader remains centered as a whole within the content area.
+- All existing animations continue to play as before.
+
+## Acceptance Criteria
+
+- The loading status group (text + progress bar + indicators) renders centered directly beneath the polygon, matching a clean vertical-stack layout (verified against the intent of `c:\dev\sc2.png`, where it currently sits lower-right).
+- No horizontal offset/drift of the status group relative to the polygon at any breakpoint.
+- The arrangement is verified on mobile (~375px), tablet (~768px), and desktop (≥1366px) — centered, no overflow, no horizontal scrollbar.
+- All pre-existing loader animations and elements are preserved and still animate correctly.
+- The loader renders correctly in both light and dark themes (it is dark-gradient based; confirm no regression).
+
+## Reminders
+
+- Perform comprehensive testing on implemented changes before you proceed to pull request (PR) submission. Compare against `c:\dev\sc2.png` and attach a before/after screenshot.
+- This is a **presentation-layer / layout change** to the loader only. Do not change where or when the loader is mounted, or any data/loading logic.
+
+## Instructions
+
+- Adhere to branch naming convention: `task-name/your-name`. Commit all relevant code changes to this branch before creating pull request.
+- Include comprehensive description in pull request that clearly documents all code changes and their purpose. Attach before/after screenshots showing the status group centered below the polygon.
+- Request review from assigned team lead when submitting pull request.
+- Maintain task status by moving cards to appropriate Kanban columns as work progresses.
+
+## Got any questions?
+
+For any questions, don't hesitate to ask your assigned team lead. You may reach out via messenger team group chat.
+</content>

--- a/docs/tasks/Raineer-FE/Kanban-Ticket-Modal-Responsive-Fix-Review-Notes.md
+++ b/docs/tasks/Raineer-FE/Kanban-Ticket-Modal-Responsive-Fix-Review-Notes.md
@@ -1,0 +1,96 @@
+# Kanban Ticket Modal — Responsive Fix Review Notes
+## Implementation reference / for review discussion — prepared by Deo
+
+**Assigned to:** Raineer Dela Rita (`delaritaraineer81`)
+
+> Companion to [`Kanban-Ticket-Modal-Responsive-Fix.md`](./Kanban-Ticket-Modal-Responsive-Fix.md).
+> Files: `apps/codebility/app/home/kanban/[projectId]/[id]/_components/tasks/` — `TaskViewModal.tsx`, `TaskAddModal.tsx`, `TaskEditModal.tsx`.
+> Repro: 1366×768 laptop (usable height ~700px). Reference screenshot: `c:\dev\sc4.png`.
+
+---
+
+## Short summary — to discuss with the author
+
+> The ticket modal's close (✕) button and bottom action buttons get cut off on a 1366×768 laptop. Root cause: the modal's height isn't capped to the viewport, so when its content is taller than the screen the centered modal spills off the top and bottom — and even though it has `overflow-y-auto`, the off-screen edges can't be scrolled into view because the whole box is positioned partly outside the viewport. **Two modals are affected — `TaskViewModal` and `TaskAddModal`** — both because they size with `h-auto` and cap at a fixed `900px` (or let `sm:max-h-[900px]` override the `vh` cap) instead of capping to the viewport. **`TaskEditModal` is already fine** — it uses `h-[95vh]`, which is exactly the pattern the other two should adopt. The one-line height-cap fix below resolves the reported bug; the optional structural change (pinned footer) hardens all three.
+
+---
+
+## Findings — all three modals at 1366px
+
+The custom breakpoints in `tailwind.config.ts` (`phone`/`tablet`/`laptop`/`desktop`) are **max-width** ranges (≤425/≤767/≤1024/≤1280), so none apply at 1366px — only base + default `sm:` (preserved via `extend`) classes are in effect.
+
+| Modal | Height classes effective at 1366px | At 1366×768 | Verdict |
+|---|---|---|---|
+| **TaskViewModal** (`:688`) | `h-auto max-h-[90vh]` **+ `sm:max-h-[900px]`** | `sm:` (≥640) overrides the vh cap → effective `max-h-[900px]`, content-sized. Exceeds the viewport → ✕ + footer clipped. | 🔴 **Fix required** (reported defect) |
+| **TaskAddModal** (`:721`) | `h-auto max-h-[900px]` *(no vh cap)* | `phone:`/`tablet:` are max-width → don't apply at 1366. Base fixed 900px cap → same clipping. | 🔴 **Fix required** |
+| **TaskEditModal** (`:461`) | `h-[95vh] max-h-[900px]` | `h-[95vh]` ties height to viewport (≈730px < 900px cap) → fits at all widths. | 🟢 **Verify only** |
+
+---
+
+## Fix A — minimal, resolves the reported bug (recommended first)
+
+Cap the modal height to the viewport at all widths. Capping to `max-h-[90vh]` keeps the box inside the screen; the existing `overflow-y-auto` then scrolls the content internally, and the absolutely-positioned ✕ (top) and footer (bottom) stay on-screen.
+
+**`TaskViewModal.tsx:688`** — drop the `sm:max-h-[900px]` override:
+
+```diff
+- <DialogContent className="h-auto max-h-[90vh] w-[95vw] max-w-3xl overflow-y-auto bg-white p-3 dark:bg-gray-900 sm:max-h-[900px] sm:w-[90vw] sm:p-4">
++ <DialogContent className="h-auto max-h-[90vh] w-[95vw] max-w-3xl overflow-y-auto bg-white p-3 dark:bg-gray-900 sm:w-[90vw] sm:p-4">
+```
+
+**`TaskAddModal.tsx:721`** — change the fixed `max-h-[900px]` to a viewport cap:
+
+```diff
+- <DialogContent className="phone:h-full phone:w-full tablet:h-full tablet:w-full h-auto max-h-[900px] w-[95vw] max-w-3xl overflow-y-auto bg-white p-4 dark:bg-gray-900">
++ <DialogContent className="phone:h-full phone:w-full tablet:h-full tablet:w-full h-auto max-h-[90vh] w-[95vw] max-w-3xl overflow-y-auto bg-white p-4 dark:bg-gray-900">
+```
+
+**`TaskEditModal.tsx`** — no change needed for the bug; already viewport-bound via `h-[95vh]`.
+
+> Optional refinement: use `max-h-[90dvh]` (dynamic viewport height) instead of `90vh` so the cap accounts for mobile browser address-bar collapse. Safe in modern browsers; keep `90vh` if you want to avoid any older-browser concern.
+
+---
+
+## Fix B — structural hardening (optional, makes all three rock-solid)
+
+Fix A relies on the footer being reachable by scrolling within the capped modal. To guarantee the header (with ✕) and footer (action buttons) are **always pinned and visible** regardless of content length, restructure each `DialogContent` into a flex column: fixed header → scrollable body → fixed footer.
+
+```tsx
+// Pattern to apply to View / Add (and optionally Edit for consistency)
+<DialogContent className="flex max-h-[90vh] w-[95vw] max-w-3xl flex-col overflow-hidden bg-white p-0 dark:bg-gray-900 sm:w-[90vw]">
+  {/* Header stays pinned; shadcn's ✕ is absolute and remains visible */}
+  <DialogHeader className="shrink-0 border-b px-4 py-3 dark:border-gray-800">
+    {/* title … */}
+  </DialogHeader>
+
+  {/* Only this region scrolls */}
+  <div className="flex-1 overflow-y-auto px-4 py-4">
+    {/* all the fields: Priority, Difficulty, Task Type, PR Link, Skill Category,
+        Deadline, Primary Assignee, Description … */}
+  </div>
+
+  {/* Footer stays pinned at the bottom */}
+  <DialogFooter className="shrink-0 border-t px-4 py-3 dark:border-gray-800">
+    {/* action buttons … */}
+  </DialogFooter>
+</DialogContent>
+```
+
+Key points:
+- `flex flex-col` + `overflow-hidden` on `DialogContent`, `max-h-[90vh]` cap.
+- Body wrapper gets `flex-1 overflow-y-auto` (move the scroll here, off `DialogContent`).
+- Header and footer get `shrink-0` so they never compress or scroll away.
+- Moving padding from `DialogContent` (`p-3`/`p-4`) onto the inner regions avoids the scroll area clipping under the padded edge.
+
+---
+
+## Verification checklist (acceptance criteria)
+
+- [ ] **1366×768**: ✕ and all footer buttons fully visible and clickable without resizing/zooming.
+- [ ] Long-content ticket: only the body scrolls; header + footer stay put.
+- [ ] Widths: mobile (~375px), tablet (~768px), laptop (1366px), desktop (≥1920px) — no clipped controls, no horizontal scroll, no page-level overflow.
+- [ ] Consistent behavior across **View / Add** (and **Edit** if Fix B applied).
+- [ ] Light **and** dark themes render correctly.
+- [ ] No regressions to fields, dropdowns, PR link, assignee, description, or save/cancel/close actions (presentation-layer only).
+- [ ] Before/after screenshots at 1366×768 attached to the PR.
+</content>

--- a/docs/tasks/Raineer-FE/Kanban-Ticket-Modal-Responsive-Fix.md
+++ b/docs/tasks/Raineer-FE/Kanban-Ticket-Modal-Responsive-Fix.md
@@ -1,0 +1,68 @@
+# Kanban Ticket Modal — Responsive Layout Fix
+
+**Assigned to:** Raineer Dela Rita (`delaritaraineer81`) · **Branch:** `kanban-ticket-modal-responsive-fix/raineer`
+
+## Summary
+
+The **task/ticket modal** in the Kanban board (opened via a task card, URL `…/home/kanban/[projectId]/[id]?taskId=…`) does not fit within shorter viewports. On a typical laptop display (e.g. **1366×768**, where usable browser height is only ~625–700px after the address bar and OS chrome), the modal grows taller than the screen and — because the dialog is vertically centered — its content **spills off both the top and the bottom of the viewport**. The result is that the **close (✕) button at the top is hidden** and the **action buttons at the bottom of the modal are hidden**, leaving the user unable to close the modal or submit/save without an external workaround (resizing the window, browser zoom-out, etc.).
+
+This task makes the ticket modal fully responsive so that the close button and all footer action buttons remain visible and reachable on **all viewport sizes**, with the modal body scrolling internally rather than the whole modal overflowing the screen.
+
+## Technical Context
+
+All three modals live in `apps/codebility/app/home/kanban/[projectId]/[id]/_components/tasks/`. The project's custom breakpoints (`phone`/`tablet`/`laptop`/`desktop`, defined in `apps/codebility/tailwind.config.ts`) are **max-width** ranges (≤425 / ≤767 / ≤1024 / ≤1280), so at the reported **1366px** width none of them apply — only the **base** (and default `sm:`, which is preserved via `extend`) classes are in effect. That is what exposes the bug.
+
+**Affected — fix required:**
+
+- **`TaskViewModal.tsx`** (`DialogContent`, ~line 688): className is `h-auto max-h-[90vh] … sm:max-h-[900px]`. The `sm:max-h-[900px]` (applies ≥640px) **overrides** the `max-h-[90vh]` cap, so on any screen wider than 640px but shorter than 900px (all standard laptops) the content-sized (`h-auto`) modal exceeds the viewport. Centered → ✕ (top) and footer buttons (bottom) are clipped. **This is the reported defect.**
+- **`TaskAddModal.tsx`** (`DialogContent`, ~line 721): className is `phone:h-full tablet:h-full … h-auto max-h-[900px]`. The full-screen `phone:`/`tablet:` rules only cover ≤767px; at 1366px the base `h-auto max-h-[900px]` applies with **no `vh` cap at all**, producing the same clipping. Same fix applies.
+
+**Not affected — verify only:**
+
+- **`TaskEditModal.tsx`** (`DialogContent`, ~line 461): className is `… laptop:h-[90vh] laptop:max-h-[800px] h-[95vh] max-h-[900px]`. The base `h-[95vh]` ties height to the viewport (≈730px on a 768px screen, under the 900px cap), so it stays on-screen at all widths. This is the pattern the other two should adopt. Optional polish: it still scrolls the whole `DialogContent` rather than pinning the footer — folding it into the fixed-header/scrollable-body/fixed-footer restructure would make all three consistent.
+
+## Objectives
+
+- Ensure the ticket modal's **height is always capped to the viewport** (e.g. `max-h-[90vh]` / `max-h-[90dvh]`) at **every** breakpoint — remove or correct the fixed `sm:max-h-[900px]` override that lets it exceed short screens.
+- Restructure the modal into a **fixed header / scrollable body / fixed footer** layout (flex column) so that:
+  - the **close (✕) button** stays pinned and visible at the top, and
+  - the **action buttons** stay pinned and visible at the bottom,
+  - regardless of how much content the body holds.
+- Make the **modal body the only scrollable region** (internal scroll), instead of the entire modal overflowing the page.
+- Verify and align the same behavior across the **Add / View / Edit** task modals if they share the layout.
+- Preserve existing functionality — all fields, dropdowns (Priority, Difficulty, Skill Category, Deadline), PR Link, Primary Assignee, Description, and the save/cancel/close actions must continue to work unchanged. This is a **layout/presentation fix only**.
+
+## Expected Behavior
+
+- Opening a ticket on a **1366×768** laptop shows the modal fully within the viewport: the ✕ button is visible at the top and the action buttons are visible at the bottom **without scrolling the page**.
+- When the ticket content is taller than the available space, **only the modal body scrolls**; the header (with ✕) and footer (action buttons) remain fixed and visible.
+- The close button is always clickable, and all footer buttons are always reachable, on small (mobile), medium (tablet), and large (desktop) viewports, and on short laptop heights.
+- No horizontal overflow or layout shift is introduced at any breakpoint.
+- The modal continues to render correctly in both **light and dark themes**.
+
+## Acceptance Criteria
+
+- On a 1366×768 viewport (and other short-height laptop resolutions), the ticket modal's close (✕) button and bottom action buttons are both fully visible and operable without resizing the window or zooming out.
+- The modal's overall height never exceeds the viewport; when content overflows, the **body scrolls internally** while the header and footer stay pinned.
+- The fix is verified across representative widths — mobile (~375px), tablet (~768px), laptop (1366px), and desktop (≥1920px) — with no clipped controls, no page-level overflow, and no horizontal scrollbar.
+- Behavior is consistent across the **Add**, **View**, and **Edit** task modals (whichever share this layout).
+- The modal renders correctly in both light and dark themes.
+- All existing fields, inputs, dropdowns, and the save/cancel/close actions function exactly as before — no regressions to data entry or persistence.
+
+## Reminders
+
+- Perform comprehensive testing on implemented changes before you proceed to pull request (PR) submission. **Test specifically at 1366×768** (the reported failing case), and confirm the fix at small/medium/large widths.
+- This is a **presentation-layer change**. Do **not** modify the task data model, the server actions that persist tasks, or the data passed into the modal.
+- Attach before/after screenshots at 1366×768 demonstrating that the close button and footer buttons are now visible.
+
+## Instructions
+
+- Adhere to branch naming convention: `task-name/your-name`. Commit all relevant code changes to this branch before creating pull request.
+- Include comprehensive description in pull request that clearly documents all code changes and their purpose. Attach before/after screenshots at the failing resolution (1366×768) plus at least one mobile-width screenshot.
+- Request review from assigned team lead when submitting pull request.
+- Maintain task status by moving cards to appropriate Kanban columns as work progresses.
+
+## Got any questions?
+
+For any questions, don't hesitate to ask your assigned team lead. You may reach out via messenger team group chat.
+</content>

--- a/docs/tasks/Raineer-FE/Onboarding-Videos-Egress-Quota-Fix.md
+++ b/docs/tasks/Raineer-FE/Onboarding-Videos-Egress-Quota-Fix.md
@@ -1,0 +1,115 @@
+# Onboarding Videos — Storage Egress Quota Fix
+
+## Summary
+
+Our Supabase organization (Codebility) blew past its **Cached egress (bandwidth)** quota for the billing cycle — **354.83 GB used against a 275 GB included allowance** — which caused Supabase to **restrict the whole project**: API, Auth, and Storage requests were dropped (returning `500 ... exceed_cached_egress_quota`), so users could not even log in. Only the Supabase dashboard stayed accessible.
+
+The root cause is the **applicant onboarding videos**. The four videos (`part1.mp4`–`part4.mp4`, ~5.8 GB total, with `part1.mp4` alone ~716 MB) are served directly from a **public Supabase Storage bucket** and the player uses **`preload="auto"`**, so the browser starts downloading the entire video the moment the onboarding screen mounts — before the user even presses play. Combined with full re-downloads on retry/navigation and a public, scrape-able bucket, this single feature is responsible for the bulk of the egress.
+
+This task stops the bleeding (so login/service can't be taken down by video bandwidth again) and moves video delivery off Supabase egress for good. **It does not touch auth logic, data models, or server actions** — it's contained to the onboarding video delivery layer plus a hosting/bucket change.
+
+## Technical Context
+
+Confirmed by inspecting the code:
+
+- **`apps/codebility/app/applicant/onboarding/_components/OnboardingClient.tsx:19-24`** — `VIDEO_URLS` hardcodes four public Storage URLs:
+  `https://hibnlysaokybrsufrdwp.supabase.co/storage/v1/object/public/codebility/onboarding-videos/partN.mp4`
+- **`apps/codebility/app/applicant/onboarding/_components/VideoPlayer.tsx:191-202`** — renders a native `<video preload="auto">` with `<source src={videoUrl}>`. The inline comment literally says *"Start loading immediately"* — this is what triggers a full-file download on mount, watched or not.
+- **`apps/codebility/app/applicant/onboarding/_components/VideoPlayer.tsx:156-162`** — `handleRetry()` calls `videoRef.current.load()`, which **restarts the download from zero**. Once quota errors began, users hitting "Retry" each re-pulled the whole file — a feedback loop that accelerated egress.
+- File sizes per `apps/codebility/docs/VIDEO_UPLOAD_GUIDE.md` — `part1.mp4 ~716 MB`; four parts ~5.8 GB.
+- The `codebility` Storage bucket is **public**, and the URLs are static/hardcoded, so bots or any leaked link can pull GBs with no auth.
+- "Cached egress" on Supabase = **Storage CDN bandwidth**. Database/REST egress is a separate line, so the overage is overwhelmingly Storage downloads → the videos.
+
+Math sanity-check: 354 GB ÷ 5.8 GB ≈ ~61 full download sets. With `preload="auto"`, you don't need 61 completed onboardings — just that many page visits + retries + back/forward navigations, each pulling a large chunk. Entirely consistent with the videos being the cause.
+
+## Objectives
+
+1. **Immediate mitigation (highest priority, ship first):**
+   - Change the player from `preload="auto"` to **`preload="none"`** (or `"metadata"` if a poster/duration is needed). The video must download **only after the user clicks play**, never on mount.
+   - Fix `handleRetry()` so it does not restart a full download unnecessarily (only reload when the source genuinely errored, and prefer resuming over restarting from zero).
+2. **Move video delivery off Supabase egress (primary fix) — use Mux:**
+   - **Re-host the four onboarding videos on [Mux](https://www.mux.com/) using its free plan** (at time of writing: up to **10 on-demand videos** and **100,000 delivery minutes/month** free, no credit card). We only have 4 videos, so this should be **$0/month** and takes video bandwidth fully off Supabase. **Verify the current free-plan limits at signup before building on them** — provider free tiers change.
+   - **Why Mux over the alternatives:** Mux gives an **HLS URL that drops into the existing native `<video src>`**, so the current watch-completion / sequential-unlock logic (driven by native `<video>` `timeupdate`/`ended` events) keeps working with minimal change. It also does adaptive bitrate, so users no longer pull the full 716 MB file.
+   - **Fallbacks if Mux doesn't fit:**
+     - **Bunny Stream** — if we ever exceed Mux's 10-video free cap. Not free (≈$1/month minimum + low bandwidth) but very cheap; also HLS-based, so the same minimal player change applies.
+     - **Unlisted YouTube/Vimeo** — truly free with no API setup, BUT requires replacing the native `<video>` element with the provider's **iframe embed** and **rewriting progress tracking against the YouTube IFrame Player API**, and inherits provider branding ("Watch on YouTube", logo) plus video-unavailable risk. Choose this only if zero hosting setup outweighs the extra player rework. **Do NOT use Cloudflare Stream** — no free tier, $5/month floor.
+   - Replace the hardcoded `VIDEO_URLS` with the new host's URLs (ideally via env vars / config, not hardcoded literals).
+3. **Reduce file size regardless of host:**
+   - Re-encode the videos (H.264/H.265, 720p, sane bitrate). 716 MB for one onboarding clip is far too high; expect a 5–10× reduction.
+4. **Lock down the source bucket (if any video stays on Supabase):**
+   - Make the bucket private and serve via **signed URLs** with a short TTL, so the files can't be scraped by bots or shared links.
+
+## Expected Behavior
+
+- Visiting the onboarding screen (`/applicant/onboarding`) downloads **no video bytes** until the user actually presses play on a given video.
+- Navigating between video steps or retrying a failed load does **not** trigger a fresh full-file download.
+- Videos play correctly through the onboarding flow, and the existing watch-completion / sequential-unlock logic still works (do not regress the 90% completion gating).
+- Video bandwidth no longer counts against Supabase Cached egress (or is drastically reduced if any file remains on Supabase).
+
+## Acceptance Criteria
+
+- `VideoPlayer.tsx` no longer uses `preload="auto"`; verified in the browser **Network tab** that loading the onboarding page issues **no large video request** until play is pressed.
+- Retry/navigation no longer re-downloads the entire file from zero (verified in Network tab).
+- The four videos are served from **Mux** (or an approved fallback / signed private Storage URLs); `VIDEO_URLS` no longer points at the public `…/object/public/…` Supabase path (or, if interim, is behind signed URLs).
+- Re-encoded files are meaningfully smaller (document before/after sizes in the PR).
+- Onboarding still functions end-to-end: all four videos play, completion tracking and sequential unlocking work, quiz/commitment steps unaffected.
+- PR includes Network-tab before/after evidence (no video bytes on mount) and the new total egress footprint estimate.
+
+## Implementation Notes (Mux)
+
+Concrete steps for the recommended Mux path:
+
+1. **Create the Mux account & assets**
+   - Sign up at [mux.com](https://www.mux.com/) and confirm the **free plan limits still apply** (≤10 videos, 100k delivery min/mo at time of writing).
+   - Download the current source files from **Supabase Dashboard → Storage → `codebility/onboarding-videos`** (dashboard works even while the project is restricted).
+   - **(Recommended) re-encode first** (H.264, 720p, sane bitrate) — 716 MB per clip is far too high — then upload the four files to Mux. Upload via the Mux dashboard, the [direct-upload](https://www.mux.com/docs) flow, or the API.
+   - For each asset, grab its **Playback ID** and build the HLS URL: `https://stream.mux.com/{PLAYBACK_ID}.m3u8`.
+
+2. **Wire the URLs through config, not hardcoded literals**
+   - Replace the hardcoded `VIDEO_URLS` in `OnboardingClient.tsx:19-24` with the four Mux HLS URLs.
+   - Prefer env vars (e.g. `NEXT_PUBLIC_ONBOARDING_VIDEO_1` … `_4`) or a config object so the URLs aren't baked into the component. Add them to `.env.local` and the app's env example file.
+
+3. **⚠️ HLS playback gotcha — the most important step**
+   - A native `<video><source src="….m3u8" type="application/x-mpegURL"></video>` plays HLS **only in Safari/iOS**. **Chrome, Edge, and Firefox do NOT play `.m3u8` natively** — the current `VideoPlayer.tsx` would just error there.
+   - Fix: add **[`hls.js`](https://github.com/video-dev/hls.js)** (`pnpm add hls.js` in `apps/codebility`). In `VideoPlayer.tsx`, attach it to the `videoRef`:
+     ```tsx
+     import Hls from "hls.js";
+     // inside an effect, after the <video> ref is available:
+     const video = videoRef.current;
+     if (video.canPlayType("application/vnd.apple.mpegurl")) {
+       video.src = videoUrl;                 // Safari plays HLS natively
+     } else if (Hls.isSupported()) {
+       const hls = new Hls();
+       hls.loadSource(videoUrl);
+       hls.attachMedia(video);
+       // remember to hls.destroy() on cleanup / videoUrl change
+     }
+     ```
+   - Keep using the **native `<video>` element** so the existing `timeupdate` / `ended` / `loadedmetadata` handlers that drive the 90% completion gate and sequential unlock continue to work unchanged. `hls.js` feeds the same `<video>`, so those events still fire.
+   - Replace `preload="auto"` with `preload="none"` (Objective 1) — with `hls.js` you control load timing explicitly, so don't start the HLS load until the user presses play.
+   - Alternatively, the official **`@mux/mux-player-react`** component bundles HLS handling and emits standard media events — simpler, but it's a larger swap of the player UI; using `hls.js` with the existing `<video>` is the lower-risk change.
+
+4. **Verify**
+   - In the browser **Network tab**: loading `/applicant/onboarding` pulls **no video segments** until play is pressed; playback then streams `.ts`/segment requests from `stream.mux.com` (not Supabase).
+   - Test in **Chrome AND Safari** (HLS behaves differently across them).
+   - Re-confirm the **90% watch-completion gate** and **sequential unlock** still work, and that retry/navigation don't restart full downloads.
+
+## Reminders
+
+- **Do not change** auth, middleware, data models, or server actions — this is the video delivery layer only. The login failures were a *symptom* of the quota, not a code bug; they resolve once egress is under control.
+- Confirm the cause first via **Supabase Dashboard → Reports/Usage → Egress** (Storage/Cached egress breakdown) and **Storage Logs** (repeated `GET …/onboarding-videos/partN.mp4`) before and after the fix, and include those numbers in the PR.
+- Keep the watch-completion threshold and sequential-unlock behavior intact — re-test them after swapping the player/source.
+- Download the current videos from **Supabase Dashboard → Storage → `codebility/onboarding-videos`** (dashboard access works even while restricted) to re-encode/re-host them.
+- Coordinate the actual file re-host/upload and any bucket privacy change with the team lead (credentials/access to the Mux account or chosen host).
+- If you switch to an iframe-based fallback (YouTube/Vimeo), budget extra time to rewrite the watch-completion tracking against the provider's player API and re-verify the 90% gate — this is why Mux (native `<video>`) is the default.
+
+## Instructions
+
+- Branch naming: `onboarding-video-egress/your-name`. Commit all changes to this branch before opening the PR.
+- Ship the **`preload` mitigation as a small first commit/PR** if the re-hosting will take longer — it's the highest-impact, lowest-risk change and prevents a repeat outage.
+- Include a comprehensive PR description: files touched, the new host, before/after file sizes, before/after Network-tab screenshots, and the Usage Dashboard egress reading.
+- Request review from your team lead. Maintain Kanban card status as work progresses.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.

--- a/docs/tasks/Raineer-FE/Portal-UI-Consistency-Accessibility-Pass.md
+++ b/docs/tasks/Raineer-FE/Portal-UI-Consistency-Accessibility-Pass.md
@@ -1,0 +1,64 @@
+# Portal UI/UX Consistency & Accessibility Pass
+
+## Summary
+
+The Codebility portal (`apps/codebility/app/home/**`) has grown quickly and accumulated UI/UX inconsistencies that hurt polish and accessibility: many data-driven views lack loading and empty states, several components hardcode dark colors instead of using the theme/design-system tokens (so they look broken in light mode), and a number of icon-only buttons have no accessible label. This task is a focused, presentation-layer consistency pass across the portal to bring these up to a consistent standard using the existing `@codevs/ui` design system and `next-themes`.
+
+This is **presentation-layer only** — no data model, server action, or query-logic changes.
+
+> Note: this is the larger sprint task for Raineer and runs alongside his two smaller standalone fixes (the Kanban ticket-modal responsive fix and the home-page loader enhancement). Those can be folded into this pass or shipped separately.
+
+## Technical Context & Confirmed Anchors
+
+- **Theme inconsistency (confirmed pattern):** several pages hardcode dark palette classes (e.g. `bg-neutral-900`, `text-neutral-400`) instead of design-system/theme tokens, so they don't respond to light mode. A clear example is the appointments admin page (`app/home/admin-controls/appointments/`), reviewed and found to hardcode dark colors with no `next-themes` support. Use the design system's themable tokens (the way the main Add-Members list and other `@codevs/ui` components do).
+- **Loading / empty states:** many `"use client"` views fetch data without a skeleton/spinner or a graceful empty state. Catalogue these during the audit (kanban task views, my-team grids, feeds, member selection modals are reported starting points — confirm each).
+- **Accessibility:** icon-only buttons (using `lucide-react` icons with no text) frequently lack `aria-label`. Add labels so screen readers and tests can identify them.
+- **Design system:** prefer existing primitives from `@codevs/ui` and the shared Tailwind config; do not introduce new one-off styles where a tokenized component exists.
+
+> Because specific instance lists drift, **start with an audit** (Sprint 1) that produces the concrete worklist, rather than treating any single reported file as gospel.
+
+## Objectives
+
+- Add consistent **loading states** (skeletons/spinners) to data-driven portal views that currently render nothing or jump on load.
+- Add graceful **empty states** (icon + message) to lists/grids/tables that can be empty.
+- Replace **hardcoded dark-only colors** with theme/design-system tokens so every audited view renders correctly in **both light and dark** themes.
+- Add **`aria-label`** (or visually-hidden text) to icon-only buttons and controls that lack an accessible name.
+- Keep everything within the existing `@codevs/ui` design system and Tailwind conventions — consistency, not new visual language.
+
+## Sprint Plan (1 fortnightly sprint)
+
+- **Week 1:** Audit the `app/home/**` surface and produce a concrete worklist (a checklist of views needing loading states, empty states, theme fixes, and a11y labels). Then fix the highest-traffic areas: dashboard, kanban, my-team. Establish/confirm reusable skeleton + empty-state components so fixes are consistent.
+- **Week 2:** Work through the remaining views (settings, applicants, feeds, overflow, admin-controls incl. the appointments theme fix), add the a11y labels, and do a light/dark + responsive verification pass across everything touched.
+
+## Expected Behavior
+
+- Data-driven views show a loading indicator while fetching and a clear empty state when there's no data — no blank flashes or layout jumps.
+- Every audited view renders correctly in light and dark mode; no hardcoded dark-only colors remain in the touched files.
+- Icon-only buttons have accessible names.
+- No change to what data is shown or how features behave — visual/accessibility polish only.
+
+## Acceptance Criteria
+
+- An audit worklist is produced and tracked (so coverage is explicit, not implied).
+- The audited views have appropriate loading and empty states using shared/reusable components.
+- Touched views render correctly in both light and dark themes (verified by toggling), with no remaining hardcoded dark-only palette classes in those files.
+- Icon-only buttons/controls in the touched views have `aria-label`s (or equivalent accessible names).
+- Responsive check on touched views (mobile/tablet/desktop) shows no overflow or layout breakage.
+- No functional/data regressions; this is presentation-layer only.
+- Before/after screenshots (light + dark) attached to the PR for representative views.
+
+## Reminders
+
+- Presentation layer only — do not modify data fetching, server actions, or query logic.
+- Reuse `@codevs/ui` primitives and shared Tailwind tokens; avoid one-off styles.
+- Perform comprehensive testing (light/dark + responsive) before PR.
+
+## Instructions
+
+- Branch: `portal-ui-consistency-pass/raineer`. One PR per phase is recommended; keep PRs reviewable.
+- Comprehensive PR description with the audit worklist and before/after screenshots. Request team-lead review. Maintain Kanban status.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.
+</content>

--- a/docs/tasks/Raineer-FE/Public-Pages-SEO-Followup-MetadataBase-JSONLD-Headings.md
+++ b/docs/tasks/Raineer-FE/Public-Pages-SEO-Followup-MetadataBase-JSONLD-Headings.md
@@ -1,0 +1,59 @@
+# Public Pages SEO — Follow-Up: metadataBase, Structured Data & Heading/Alt Hygiene
+
+## Summary
+
+The first SEO pass landed the sitemap, robots file, and per-page metadata (titles, descriptions, canonical URLs, Twitter cards) — that part is done and looks good. Three objectives from the original task were not completed, and one of them silently cancels out a lot of the work that was done. This follow-up closes those three gaps: set `metadataBase`, add JSON-LD structured data, and fix the heading/alt-text hygiene on the marketing pages.
+
+## Background
+
+Current state on `dev`:
+
+- `app/layout.tsx` still has **no `metadataBase`**. Every Open Graph and Twitter image across the site uses a relative path (`/og-image.jpg`, relative profile images). Without `metadataBase`, Next.js can't turn those into absolute production URLs, so social previews still render without an image — and Next logs a build warning on every page. This is the single most important gap because it undermines all the per-page OG/Twitter work already shipped.
+- There is **no JSON-LD anywhere** in the app (no `application/ld+json`). None of the structured-data objectives were done: no Organization/WebSite sitewide, no JobPosting on careers, no Person on `profiles/[id]`, no Service on services.
+- The **heading and alt hygiene** was not touched. `LandingWhyChoose.tsx` still renders 7 `<h1>` elements and `CodevsProject.tsx` renders 4, so the home page and the careers/codevs/hire-a-codev pages each end up with multiple H1s. Weak and empty `alt` text remains on several content images.
+
+## Objectives
+
+- Set `metadataBase` on the root layout so all relative OG/Twitter image URLs resolve to absolute production URLs, and add sitewide OG/Twitter defaults.
+- Add JSON-LD structured data: Organization + WebSite sitewide; JobPosting on careers; Person on `profiles/[id]`; Service on the services page.
+- Ensure exactly one `<h1>` per rendered page (demote the extra H1s to `<h2>`/`<h3>`), and make image `alt` text descriptive for content images while using empty `alt=""` only for purely decorative ones.
+
+## Expected Behavior
+
+- Sharing any public page on Facebook/LinkedIn/X shows the correct image via an absolute URL; no Next.js `metadataBase` build warning remains.
+- Google Rich Results Test validates the structured data on the home page, careers, and a profile page with no errors.
+- Each public page has a single H1 and a logical heading order; content images have meaningful alt text.
+
+## Acceptance Criteria
+
+- [ ] `metadataBase` is set on the root layout; the OG image resolves to an absolute URL on every page (verify in view-source and the Facebook Sharing Debugger).
+- [ ] No `metadataBase` warning appears in the production build output.
+- [ ] JSON-LD validates on Google Rich Results Test for: Organization + WebSite (sitewide), JobPosting (careers), and Person (`profiles/[id]`).
+- [ ] Each public page renders exactly one `<h1>`; `LandingWhyChoose.tsx` and the three `CodevsProject.tsx` variants no longer emit multiple H1s.
+- [ ] Content images have descriptive `alt`; decorative images use `alt=""`.
+- [ ] Before/after Lighthouse SEO scores included in the PR (aim 95+).
+
+## Solution Hint
+
+Treat these as advisory, not prescriptive.
+
+**1. metadataBase + sitewide defaults** — in `app/layout.tsx` `generateMetadata()`, add:
+```ts
+metadataBase: new URL("https://www.codebility.tech"),
+```
+Once set, the existing relative image paths (`/og-image.jpg`) resolve automatically — no need to hardcode absolute URLs per page. Also add a sitewide `twitter` default block here (mirroring the `openGraph` block) so pages that don't override it still get a card.
+
+**2. JSON-LD** — render a `<script type="application/ld+json">` with `dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}`. Put Organization + WebSite in the root layout (or the marketing layout) so it's sitewide; put Person in `profiles/[id]/page.tsx` using the codev data already fetched there; put JobPosting on careers using the existing job-listings source; put Service on the services page. A tiny shared `<JsonLd data={...} />` component keeps it clean. Escape `<` as `\\u003c` in the stringified output as a defense against breaking out of the script tag.
+
+**3. Headings/alt** — keep the first, most important heading on each page as `<h1>` and demote the rest to `<h2>`/`<h3>`. The offenders are `_components/landing/LandingWhyChoose.tsx` (7 H1s) and the three `CodevsProject.tsx` files under `careers/`, `codevs/`, and `hire-a-codev/` (4 H1s each). For images, replace weak alt text (`alt="woman"`, `alt="tailored"`, `alt="diamond-icon"`) with descriptive text; set `alt=""` only where the image is purely decorative.
+
+## Reminders
+
+- Presentation/metadata layer only — no data-model or server-action changes. Pull dynamic values (job listings, profile data) from the existing sources.
+- Use the real production base URL everywhere.
+- Validate with the Facebook Sharing Debugger, X Card Validator, Google Rich Results Test, and Lighthouse SEO before opening the PR.
+
+## Instructions
+
+- Branch naming: `public-pages-seo-followup/<name>`. Commit all changes before opening the PR.
+- PR description: routes touched, before/after Lighthouse SEO scores, a Rich Results Test screenshot, and a working social-preview screenshot.

--- a/docs/tasks/Raineer-FE/Public-Pages-SEO-Onpage-Optimization.md
+++ b/docs/tasks/Raineer-FE/Public-Pages-SEO-Onpage-Optimization.md
@@ -1,0 +1,67 @@
+# Public Pages — SEO & On-Page Optimization
+
+## Summary
+
+Our public marketing pages are running on a single global metadata block. The root layout (`app/layout.tsx`) sets one title ("Codebility") and one description ("Everyone has the ability to code"), and **every public page inherits them unchanged** — none of the marketing pages set their own. So search engines see the same title and description across the whole site, which is the biggest on-page SEO problem we have right now. On top of that we have no sitemap, no robots file, no canonical URLs, no structured data, and the Open Graph image is effectively broken because `metadataBase` isn't set.
+
+This task brings the public pages up to a proper on-page SEO standard: unique per-page metadata, working social cards, a sitemap and robots file, canonical URLs, structured data, and cleaner heading/alt-text hygiene. It's contained to the marketing routes (`app/(marketing)/**`) and the root layout — no backend work.
+
+## Technical Context
+
+Current state (confirmed by inspecting the code):
+- `app/layout.tsx` `generateMetadata()` sets title, description, favicons, web manifest, and a basic `openGraph` block — but **no `metadataBase`**, so the relative OG image (`/og-image.jpg`) doesn't resolve to an absolute URL and social previews can render blank.
+- **Zero** marketing pages export `metadata` or `generateMetadata` — every page shares the root title/description.
+- No `app/sitemap.ts`, no `app/robots.ts`, no JSON-LD (`application/ld+json`) anywhere.
+- No `twitter:` card block, no `alternates.canonical`.
+- `profiles/[id]` (dynamic) has no `generateMetadata`, so profile pages can't get person-specific metadata.
+- Content layer: several components each render an `<h1>` (e.g. `LandingWhyChoose.tsx` ~7, `CodevsProject.tsx` ~4), so composed pages end up with multiple H1s. Image `alt` text is often decorative/weak (`alt="diamond-icon"`, `alt="tailored"`, `alt="woman"`, some empty `alt=""`).
+
+Marketing pages in scope: `/` (home), `services`, `careers`, `hire-a-codev`, `codevs`, `ai-integration`, `contact`, `bookacall`, `privacy-policy`, `profiles`, `profiles/[id]`.
+
+## Objectives
+
+- Set `metadataBase` on the root layout (e.g. `new URL("https://www.codebility.tech")`) so all relative OG/Twitter image URLs resolve correctly.
+- Give **every** marketing page a unique, keyword-relevant `<title>` and a ~150–160 character meta `description` via `export const metadata` (or `generateMetadata` for dynamic routes).
+- Add `generateMetadata` to `profiles/[id]` so each profile page gets a person-specific title/description (and OG image where available).
+- Add a `twitter` card block (`card: "summary_large_image"`, title, description, image) — sitewide default plus per-page where it differs.
+- Add canonical URLs via `alternates.canonical` to avoid duplicate-content issues (trailing slash, query params, dynamic pages).
+- Add `app/sitemap.ts` enumerating the public routes (static + dynamic profiles) and `app/robots.ts` with crawl directives and a sitemap reference.
+- Add JSON-LD structured data: `Organization` + `WebSite` sitewide; `JobPosting` on careers/job listings (for Google Jobs eligibility); `Person` on `profiles/[id]`; `Service` on services where it fits.
+- Clean up the content layer: exactly one `<h1>` per page (demote the rest to `<h2>`/`<h3>`), and make image `alt` text descriptive for content images while using empty `alt=""` only for purely decorative ones.
+
+## Expected Behavior
+
+- Each public page renders its own `<title>` and meta description in the HTML head — no two public pages share the same title/description.
+- Social shares (Facebook/LinkedIn/X) show the correct title, description, and image, with a working absolute image URL.
+- `/<base>/sitemap.xml` and `/<base>/robots.txt` are served and valid; robots references the sitemap.
+- Each page declares a canonical URL.
+- Structured data validates (Google Rich Results Test / schema.org validator) with no errors for the implemented types.
+- Each page has a single H1, a logical heading order, and meaningful alt text on content images.
+
+## Acceptance Criteria
+
+- `metadataBase` is set on the root layout; the OG image resolves to an absolute URL.
+- Every marketing page (and `profiles/[id]`) exports unique, relevant title + description metadata — verified by viewing source / `<head>` on each route.
+- A valid `sitemap.xml` (covering static routes + dynamic profiles) and `robots.txt` (with sitemap reference) are served.
+- Twitter Card and canonical (`alternates.canonical`) are present on the public pages.
+- JSON-LD is present and validates for at least `Organization`/`WebSite` sitewide, `JobPosting` on careers, and `Person` on `profiles/[id]`.
+- Each public page has exactly one `<h1>`; remaining headings use the correct level.
+- Content images have descriptive `alt`; decorative images use `alt=""`.
+- Validated with Lighthouse SEO (aim 95+) and Google Rich Results Test on representative pages; before/after Lighthouse SEO scores included in the PR.
+
+## Reminders
+
+- Presentation/metadata layer only — no changes to data models or server actions. Pull dynamic values (job listings, profile data) from the existing data sources for `generateMetadata`/JSON-LD.
+- Use the real production base URL for `metadataBase`, canonicals, sitemap, and absolute image URLs.
+- Test social previews (e.g. Facebook Sharing Debugger, X Card Validator) and run Lighthouse SEO before opening the PR.
+
+## Instructions
+
+- Branch naming: `task-name/your-name` (e.g. `public-pages-seo/<name>`). Commit all changes to this branch before opening the PR.
+- Include a comprehensive PR description with the routes touched, before/after Lighthouse SEO scores, and screenshots of working social previews.
+- Request review from your team lead. Maintain Kanban card status as work progresses.
+
+## Got any questions?
+
+Reach out to your assigned team lead via the team group chat.
+</content>

--- a/docs/tasks/Wendel-FS/Sanitize-Rich-Text-HTML-Stored-XSS.md
+++ b/docs/tasks/Wendel-FS/Sanitize-Rich-Text-HTML-Stored-XSS.md
@@ -1,0 +1,62 @@
+# Sanitize Rich-Text HTML to Close Stored XSS in Kanban Tasks
+
+## Summary
+
+Kanban task descriptions are written by project members in a rich-text editor, saved to the database, and later rendered as raw HTML with no sanitization. That means a member can put active markup into a task description — for example an image tag with an `onerror` handler — and it will run as script in the browser of every other member (including admins) who opens that task. This is a stored cross-site scripting (XSS) hole. The page that shows announcements has the same raw-HTML rendering for its content.
+
+There is currently no HTML sanitizer anywhere in the app — neither `dompurify`/`isomorphic-dompurify` nor `sanitize-html` is a dependency — so every place that renders stored HTML is unprotected.
+
+## Background
+
+Task descriptions are authored through the TipTap editor (`KanbanRichTextEditor.tsx`) and stored as HTML on the task record. They are then rendered straight into the DOM via `dangerouslySetInnerHTML` in these spots:
+
+- `app/home/kanban/[projectId]/[id]/_components/kanban_modals/KanbanRichTextDisplay.tsx` — renders `content` (the task description), used by `TaskViewModal.tsx`.
+- `app/home/kanban/[projectId]/[id]/_components/kanban_modals/KanbanAddModalMembers.tsx` — renders `task?.description` directly.
+- `app/home/announcements/AnnouncementContent.tsx` — renders `page.content` (announcement body, authored by admins, lower severity but same class of bug).
+
+None of these run the HTML through a sanitizer first, so any `<script>`, `<img onerror=...>`, `<iframe>`, `<a href="javascript:...">`, or inline event handler in the stored value executes when the content is viewed.
+
+Note: the `dangerouslySetInnerHTML` usages inside `TicketPreviewSidebar.tsx` and `InHousePreviewSidebar.tsx` are hardcoded CSS keyframes (`<style>` blocks), not user input — leave those alone, they are not a risk.
+
+## Objectives
+
+- Add a single HTML sanitization utility and run all stored/user-authored HTML through it before it is rendered.
+- Close the stored XSS on Kanban task descriptions (the highest-risk path, since any project member can author it).
+- Apply the same sanitization to the announcements content render.
+- Keep legitimate rich-text formatting working (bold, italics, lists, links, headings) — sanitize, don't strip everything.
+
+## Expected Behavior
+
+- A task description containing markup like `<img src=x onerror=alert(1)>` or `<script>...</script>` renders as inert/escaped content — no script executes when another member opens the task.
+- Normal formatting produced by the editor (bold, italic, lists, links, headings, line breaks) still displays correctly.
+- Announcement content renders with the same protection.
+- Links in sanitized content can't use dangerous schemes (no `javascript:` URLs).
+
+## Acceptance Criteria
+
+- [ ] A sanitizer dependency is added and a shared helper exists (e.g. one `sanitizeHtml` utility) that both Kanban and announcements use — no copy-pasted config.
+- [ ] `KanbanRichTextDisplay` sanitizes its `content` before rendering.
+- [ ] `KanbanAddModalMembers` sanitizes `task?.description` before rendering (or reuses the display component).
+- [ ] `AnnouncementContent` sanitizes `page.content` before rendering.
+- [ ] A task description with a known XSS payload (`<img src=x onerror=...>`, `<script>`, `javascript:` link) does not execute and is neutralized when viewed.
+- [ ] Existing well-formed rich text from the editor still renders with formatting intact.
+- [ ] The hardcoded `<style>` keyframe blocks in `TicketPreviewSidebar` / `InHousePreviewSidebar` are left unchanged.
+
+## Solution Hint
+
+Treat these as advisory, not prescriptive.
+
+- Add `isomorphic-dompurify` (works in both server and client components) or `dompurify` for client-only use, and create a small `sanitizeHtml(html: string)` helper with an allowlist that matches what the TipTap editor can produce (formatting tags, lists, links, headings) and drops scripts, event handlers, and dangerous URL schemes.
+- The cleanest path is to sanitize inside `KanbanRichTextDisplay` (one chokepoint) and have `KanbanAddModalMembers` reuse that component instead of its own `dangerouslySetInnerHTML`.
+- Decide whether to also sanitize on write (when the description is saved) in addition to on render. Sanitizing on render is the must-have; sanitizing on save as well is good defense in depth.
+
+## Reminders
+
+- Test with real payloads: create/edit a task whose description contains `<img src=x onerror=alert(1)>`, a `<script>` tag, and an `<a href="javascript:alert(1)">` link, then open it in the task view modal and confirm nothing executes.
+- Confirm an ordinary formatted description (bold, bullet list, link, heading) still looks right after the change.
+- Check both the task view modal and the add-members modal paths, since both render the description.
+
+## Instructions
+
+- Branch off `dev`, e.g. `fix/sanitize-richtext-xss`.
+- Open the PR against `dev` with a short, factual description of the vulnerability and the fix.


### PR DESCRIPTION
Add task specifications organized by developer folder (Angelo-FS, Jury-FS, Kris-BE, Raineer-FE, Wendel-FS).