### PR TITLE
feat(auth): harden project-scoped & community server actions (Week 2)

### DIFF
--- a/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { Task, TaskDraft } from "@/types/home/codev";
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireUser } from "@/lib/server/auth-guard";
 import { createNotificationAction } from "@/lib/actions/notification.actions";
 
 interface CodevMember {
@@ -10,6 +11,85 @@ interface CodevMember {
   first_name: string;
   last_name: string;
   image_url?: string | null;
+}
+
+type GuardSupabase = Awaited<ReturnType<typeof createClientServerComponent>>;
+
+// ── Authorization helpers ────────────────────────────────────────────────────
+// All kanban actions here operate on a task/column/draft id, so we resolve the
+// owning project and verify membership (admins bypass) before mutating.
+
+async function getProjectIdForColumn(
+  supabase: GuardSupabase,
+  columnId: string | null | undefined,
+): Promise<string | null> {
+  if (!columnId) return null;
+  const { data: column } = await supabase
+    .from("kanban_columns")
+    .select("board_id")
+    .eq("id", columnId)
+    .single();
+  if (!column?.board_id) return null;
+  const { data: board } = await supabase
+    .from("kanban_boards")
+    .select("project_id")
+    .eq("id", column.board_id)
+    .single();
+  return board?.project_id ?? null;
+}
+
+async function getProjectIdForTask(
+  supabase: GuardSupabase,
+  taskId: string,
+): Promise<string | null> {
+  const { data: task } = await supabase
+    .from("tasks")
+    .select("kanban_column_id")
+    .eq("id", taskId)
+    .single();
+  return getProjectIdForColumn(supabase, task?.kanban_column_id);
+}
+
+async function getProjectIdForBoard(
+  supabase: GuardSupabase,
+  boardId: string,
+): Promise<string | null> {
+  const { data: board } = await supabase
+    .from("kanban_boards")
+    .select("project_id")
+    .eq("id", boardId)
+    .single();
+  return board?.project_id ?? null;
+}
+
+// Throws "Forbidden" unless the caller is a member of the project or an admin.
+async function assertProjectMembership(
+  supabase: GuardSupabase,
+  userId: string,
+  projectId: string | null,
+): Promise<void> {
+  // If we could not resolve a project (e.g. missing row), the mutation will be a
+  // no-op against a non-existent target; authentication alone is sufficient.
+  if (!projectId) return;
+
+  const { data: me } = await supabase
+    .from("codev")
+    .select("role_id")
+    .eq("id", userId)
+    .single();
+
+  if (me?.role_id === 1) return; // admin bypass
+
+  const { data: member } = await supabase
+    .from("project_members")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("codev_id", userId)
+    .maybeSingle();
+
+  if (!member) {
+    throw new Error("Forbidden");
+  }
 }
 
 const updateDeveloperLevels = async (codevId?: string) => {
@@ -73,7 +153,9 @@ export const updateTaskColumnId = async (
   taskId: string,
   newColumnId: string,
 ): Promise<Task> => {
-  const supabase = await createClientServerComponent();
+  const { supabase, user } = await requireUser();
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  await assertProjectMembership(supabase, user.id, projectId);
 
   try {
     const { data, error } = await supabase
@@ -156,7 +238,13 @@ export const fetchAvailableMembers = async (
 export const createNewTask = async (
   formData: FormData,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
     const title = formData.get("title")?.toString();
@@ -174,11 +262,20 @@ export const createNewTask = async (
       .split(",")
       .filter(Boolean);
     const skill_category_id = formData.get("skill_category_id")?.toString();
-    const created_by = formData.get("created_by")?.toString();
+    // Never trust a client-supplied creator — derive it from the session.
+    const created_by = user.id;
     const deadline = formData.get("deadline")?.toString() || null;
 
     if (!title || !kanban_column_id || !skill_category_id) {
       return { success: false, error: "Required fields are missing (title, column, and skill category)" };
+    }
+
+    // Verify the caller belongs to the project that owns the target column.
+    const projectId = await getProjectIdForColumn(supabase, kanban_column_id);
+    try {
+      await assertProjectMembership(supabase, user.id, projectId);
+    } catch {
+      return { success: false, error: "Forbidden" };
     }
 
     const { data: newTask, error } = await supabase.from("tasks").insert([
@@ -221,9 +318,7 @@ export const createNewTask = async (
         revalidatePath(`/home/kanban/${boardData.project_id}/${columnData.board_id}`);
 
         if (codev_id && newTask?.id) {
-          const { data: { user } } = await supabase.auth.getUser();
-
-          
+          // Reuse the already-authenticated caller (checked before the mutation).
           if (user && user.id !== codev_id) {
             await createNotificationAction({
               recipientId: codev_id,
@@ -257,7 +352,20 @@ export const updateTask = async (
   formData: FormData,
   taskId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const rawCodevId = formData.get("codev_id")?.toString();
@@ -316,9 +424,7 @@ export const updateTask = async (
 
     // 3. NOTIFICATION LOGIC: Trigger if assignee changed and isn't null
     if (codev_id && codev_id !== existingTask.codev_id) {
-      // Get current user to avoid self-notification
-      const { data: { user } } = await supabase.auth.getUser();
-
+      // Reuse the already-authenticated caller (checked before the mutation).
       // Only send notification if assigning to someone else
       if (user && user.id !== codev_id) {
         // Fetch project info to build the action URL
@@ -357,7 +463,20 @@ export const updateTask = async (
 export const deleteTask = async (
   taskId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { data: taskData } = await supabase
@@ -410,7 +529,21 @@ export const createNewColumn = async (
   columnName: string,
   boardId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForBoard(supabase, boardId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { data: existingColumns, error: queryError } = await supabase
       .from("kanban_columns")
@@ -454,7 +587,20 @@ export const updateColumnPosition = async (
   columnId: string,
   newPosition: number,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForColumn(supabase, columnId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { error } = await supabase
@@ -482,7 +628,21 @@ export const updateColumnPosition = async (
 export const deleteColumn = async (
   columnId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForColumn(supabase, columnId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { error } = await supabase
       .from("kanban_columns")
@@ -506,7 +666,20 @@ export const updateColumnName = async (
   columnId: string,
   newName: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForColumn(supabase, columnId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { error } = await supabase
@@ -534,7 +707,23 @@ export const updateColumnName = async (
 export const completeTask = async (
   task: Task,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const guardProjectId = await getProjectIdForColumn(
+    supabase,
+    task.kanban_column_id,
+  );
+  try {
+    await assertProjectMembership(supabase, user.id, guardProjectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     // Extract IDs safely from both flat and nested structures
@@ -728,7 +917,29 @@ export const completeTask = async (
 export async function batchUpdateTasks(
   updates: Array<{ taskId: string; newColumnId: string }>,
 ) {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  try {
+    // Verify membership for every distinct project touched by the batch.
+    const projectIds = await Promise.all(
+      updates.map((u) => getProjectIdForTask(supabase, u.taskId)),
+    );
+    const uniqueProjectIds = [
+      ...new Set(projectIds.filter((id): id is string => Boolean(id))),
+    ];
+    for (const projectId of uniqueProjectIds) {
+      await assertProjectMembership(supabase, user.id, projectId);
+    }
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const updatePromises = updates.map(async (update) => {
       const { error } = await supabase
@@ -755,7 +966,21 @@ export async function batchUpdateTasks(
 }
 
 export async function updateTaskPRLink(taskId: string, prLink: string) {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { error } = await supabase
       .from("tasks")
@@ -804,7 +1029,21 @@ export async function updateTaskPRLink(taskId: string, prLink: string) {
 }
 
 export async function unarchiveTask(taskId: string) {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { error } = await supabase
       .from("tasks")
@@ -873,19 +1112,33 @@ export const saveDraft = async (
   formData: FormData,
   draftId?: string | null
 ): Promise<{ success: boolean; draftId?: string; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
-    const created_by = formData.get("created_by")?.toString();
+    // Never trust a client-supplied creator — derive it from the session.
+    const created_by = user.id;
     const project_id = formData.get("project_id")?.toString();
     const intended_column_id = formData.get("intended_column_id")?.toString();
 
     // Validate required fields
-    if (!created_by || !project_id || !intended_column_id) {
+    if (!project_id || !intended_column_id) {
       return {
         success: false,
-        error: "Missing required fields: created_by, project_id, or intended_column_id"
+        error: "Missing required fields: project_id or intended_column_id"
       };
+    }
+
+    // Only project members (or admins) may create/edit drafts in this project.
+    try {
+      await assertProjectMembership(supabase, user.id, project_id);
+    } catch {
+      return { success: false, error: "Forbidden" };
     }
 
     // Extract all form fields
@@ -1038,7 +1291,24 @@ export const loadDraft = async (
 export const deleteDraft = async (
   draftId: string
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const { data: draftRow } = await supabase
+    .from("task_drafts")
+    .select("project_id")
+    .eq("id", draftId)
+    .single();
+  try {
+    await assertProjectMembership(supabase, user.id, draftRow?.project_id ?? null);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { error } = await supabase
@@ -1070,7 +1340,13 @@ export const deleteDraft = async (
 export const promoteDraft = async (
   draftId: string
 ): Promise<{ success: boolean; taskId?: string; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
     // Step 1: Fetch the draft
@@ -1082,6 +1358,13 @@ export const promoteDraft = async (
 
     if (fetchError || !draft) {
       return { success: false, error: "Draft not found" };
+    }
+
+    // Only project members (or admins) may promote a draft into a task.
+    try {
+      await assertProjectMembership(supabase, user.id, draft.project_id ?? null);
+    } catch {
+      return { success: false, error: "Forbidden" };
     }
 
     // Step 2: Validate required fields for task creation
@@ -1122,9 +1405,7 @@ export const promoteDraft = async (
 
     // Step 3.5: Trigger Notification if assignee exists in the draft
     if (draft.codev_id) {
-      // Get current user to avoid self-notification
-      const { data: { user } } = await supabase.auth.getUser();
-
+      // Reuse the already-authenticated caller (checked before the mutation).
       // Only send notification if assigning to someone else
       if (user && user.id !== draft.codev_id) {
         await createNotificationAction({
@@ -1222,7 +1503,13 @@ export async function transferTaskToSprint(
   destinationSprintId: string,
   destinationColumnId?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
  
   try {
     // -------------------------------------------------------------------------
@@ -1267,6 +1554,13 @@ export async function transferTaskToSprint(
     }
  
     const projectId = sourceBoard.project_id;
+
+    // Only members of the source project (or admins) may transfer its tasks.
+    try {
+      await assertProjectMembership(supabase, user.id, projectId);
+    } catch {
+      return { success: false, error: "Forbidden" };
+    }
  
     // -------------------------------------------------------------------------
     // 3. Fetch the destination sprint and verify it belongs to the same project

--- a/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
@@ -18,59 +18,80 @@ type GuardSupabase = Awaited<ReturnType<typeof createClientServerComponent>>;
 // ── Authorization helpers ────────────────────────────────────────────────────
 // All kanban actions here operate on a task/column/draft id, so we resolve the
 // owning project and verify membership (admins bypass) before mutating.
+//
+// Resolvers return a discriminated result so assertProjectMembership can
+// distinguish "target row doesn't exist" (safe no-op) from "target exists but
+// no project could be resolved" (deny — fail closed).  See PR #609 review.
+
+type ProjectResolution =
+  | { found: false }
+  | { found: true; projectId: string | null };
 
 async function getProjectIdForColumn(
   supabase: GuardSupabase,
   columnId: string | null | undefined,
-): Promise<string | null> {
-  if (!columnId) return null;
+): Promise<ProjectResolution> {
+  if (!columnId) return { found: false };
   const { data: column } = await supabase
     .from("kanban_columns")
     .select("board_id")
     .eq("id", columnId)
     .single();
-  if (!column?.board_id) return null;
+  if (!column) return { found: false };
+  if (!column.board_id) return { found: true, projectId: null };
   const { data: board } = await supabase
     .from("kanban_boards")
     .select("project_id")
     .eq("id", column.board_id)
     .single();
-  return board?.project_id ?? null;
+  return { found: true, projectId: board?.project_id ?? null };
 }
 
 async function getProjectIdForTask(
   supabase: GuardSupabase,
   taskId: string,
-): Promise<string | null> {
+): Promise<ProjectResolution> {
   const { data: task } = await supabase
     .from("tasks")
     .select("kanban_column_id")
     .eq("id", taskId)
     .single();
-  return getProjectIdForColumn(supabase, task?.kanban_column_id);
+  if (!task) return { found: false };
+  return getProjectIdForColumn(supabase, task.kanban_column_id);
 }
 
 async function getProjectIdForBoard(
   supabase: GuardSupabase,
   boardId: string,
-): Promise<string | null> {
+): Promise<ProjectResolution> {
   const { data: board } = await supabase
     .from("kanban_boards")
     .select("project_id")
     .eq("id", boardId)
     .single();
-  return board?.project_id ?? null;
+  if (!board) return { found: false };
+  return { found: true, projectId: board.project_id ?? null };
 }
 
-// Throws "Forbidden" unless the caller is a member of the project or an admin.
+/**
+ * Throws "Forbidden" unless the caller is a member of the resolved project or
+ * an admin.  Fail-closed: if the target row exists but no project could be
+ * resolved (orphaned board, null FK, transient query failure) access is DENIED.
+ * Only when the target row itself doesn't exist (genuine no-op) is the check
+ * skipped — the subsequent mutation will harmlessly match zero rows.
+ */
 async function assertProjectMembership(
   supabase: GuardSupabase,
   userId: string,
-  projectId: string | null,
+  resolution: ProjectResolution,
 ): Promise<void> {
-  // If we could not resolve a project (e.g. missing row), the mutation will be a
-  // no-op against a non-existent target; authentication alone is sufficient.
-  if (!projectId) return;
+  // Target row doesn't exist → the mutation will be a real no-op.
+  if (!resolution.found) return;
+
+  // Target exists but project could not be resolved → DENY (fail closed).
+  if (!resolution.projectId) throw new Error("Forbidden");
+
+  const projectId = resolution.projectId;
 
   const { data: me } = await supabase
     .from("codev")
@@ -715,12 +736,12 @@ export const completeTask = async (
     return { success: false, error: "Unauthorized" };
   }
 
-  const guardProjectId = await getProjectIdForColumn(
-    supabase,
-    task.kanban_column_id,
-  );
+  // Authorize against the DB-trusted task id, NOT the client-supplied
+  // task.kanban_column_id — the whole `task` object is attacker-controlled.
+  // See PR #609 review, should-fix #2.
+  const guardResolution = await getProjectIdForTask(supabase, task.id);
   try {
-    await assertProjectMembership(supabase, user.id, guardProjectId);
+    await assertProjectMembership(supabase, user.id, guardResolution);
   } catch {
     return { success: false, error: "Forbidden" };
   }
@@ -927,14 +948,26 @@ export async function batchUpdateTasks(
 
   try {
     // Verify membership for every distinct project touched by the batch.
-    const projectIds = await Promise.all(
+    const resolutions = await Promise.all(
       updates.map((u) => getProjectIdForTask(supabase, u.taskId)),
     );
+
+    // Fail-closed: if any target exists but has no resolvable project, deny.
+    for (const res of resolutions) {
+      if (res.found && !res.projectId) {
+        throw new Error("Forbidden");
+      }
+    }
+
     const uniqueProjectIds = [
-      ...new Set(projectIds.filter((id): id is string => Boolean(id))),
+      ...new Set(
+        resolutions
+          .filter((r): r is { found: true; projectId: string } => r.found && r.projectId !== null)
+          .map((r) => r.projectId),
+      ),
     ];
     for (const projectId of uniqueProjectIds) {
-      await assertProjectMembership(supabase, user.id, projectId);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId });
     }
   } catch {
     return { success: false, error: "Forbidden" };
@@ -1136,7 +1169,7 @@ export const saveDraft = async (
 
     // Only project members (or admins) may create/edit drafts in this project.
     try {
-      await assertProjectMembership(supabase, user.id, project_id);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId: project_id ?? null });
     } catch {
       return { success: false, error: "Forbidden" };
     }
@@ -1305,7 +1338,7 @@ export const deleteDraft = async (
     .eq("id", draftId)
     .single();
   try {
-    await assertProjectMembership(supabase, user.id, draftRow?.project_id ?? null);
+    await assertProjectMembership(supabase, user.id, draftRow ? { found: true, projectId: draftRow.project_id ?? null } : { found: false });
   } catch {
     return { success: false, error: "Forbidden" };
   }
@@ -1362,7 +1395,7 @@ export const promoteDraft = async (
 
     // Only project members (or admins) may promote a draft into a task.
     try {
-      await assertProjectMembership(supabase, user.id, draft.project_id ?? null);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId: draft.project_id ?? null });
     } catch {
       return { success: false, error: "Forbidden" };
     }
@@ -1557,7 +1590,7 @@ export async function transferTaskToSprint(
 
     // Only members of the source project (or admins) may transfer its tasks.
     try {
-      await assertProjectMembership(supabase, user.id, projectId);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId });
     } catch {
       return { success: false, error: "Forbidden" };
     }

--- a/apps/codebility/app/home/kanban/[projectId]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/actions.ts
@@ -1,11 +1,9 @@
 "use server";
 
-import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireProjectMember } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 
 export async function createNewSprint(formData: FormData) {
-  const supabase = await createClientServerComponent();
-
 	const projectId = formData.get("projectId") as string;
 	const sprintStartAt = formData.get("sprint.startAt") as string;
 	const sprintEndAt = formData.get("sprint.endAt") as string;
@@ -15,6 +13,13 @@ export async function createNewSprint(formData: FormData) {
 
 	if (!projectId || !sprintStartAt || !sprintEndAt || !boardName) {
 		return { success: false, error: "Missing required fields" };
+	}
+
+	let supabase;
+	try {
+		({ supabase } = await requireProjectMember(projectId));
+	} catch {
+		return { success: false, error: "Forbidden" };
 	}
 
 	try {
@@ -83,8 +88,6 @@ export async function createNewSprint(formData: FormData) {
 }
 
 export async function EditSprint(formData: FormData) {
-  const supabase = await createClientServerComponent();
-
 	const sprintName = formData.get("sprintName") as string;
 	const boardName = formData.get("boardName") as string;
 	const sprintId = formData.get("sprintId") as string;
@@ -93,6 +96,13 @@ export async function EditSprint(formData: FormData) {
 
 	if (!sprintName || !boardName || !sprintId || !projectId) {
 		return { isSuccess: false, error: "Missing required fields" };
+	}
+
+	let supabase;
+	try {
+		({ supabase } = await requireProjectMember(projectId));
+	} catch {
+		return { isSuccess: false, error: "Forbidden" };
 	}
 
 	try {

--- a/apps/codebility/app/home/kanban/actions.ts
+++ b/apps/codebility/app/home/kanban/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireRole } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 
 
@@ -14,7 +14,12 @@ interface CreateBoardResult {
 export const createNewBoard = async (
   formData: FormData,
 ): Promise<CreateBoardResult> => {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireRole("kanban"));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   const name = formData.get("name")?.toString();
   const description = formData.get("description")?.toString();

--- a/apps/codebility/app/home/my-team/[projectId]/actions.ts
+++ b/apps/codebility/app/home/my-team/[projectId]/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireProjectMember, requireUser } from "@/lib/server/auth-guard";
 
 const ATTENDANCE_POINTS_PER_DAY = 2;
 
@@ -91,7 +92,12 @@ export async function saveAttendance(record: {
   check_out?: string;
   notes?: string;
 }) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireProjectMember(record.project_id));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const result = await saveAttendanceRecord(supabase, record);
@@ -155,7 +161,24 @@ export async function bulkSaveAttendance(
     notes?: string;
   }[]
 ) {
-  const supabase = await createClientServerComponent();
+  if (records.length === 0) {
+    return { success: true, results: [] };
+  }
+
+  let supabase;
+  try {
+    // Verify membership for every distinct project referenced by the batch.
+    const uniqueProjectIds = [
+      ...new Set(records.map((r) => r.project_id)),
+    ];
+    const primary = await requireProjectMember(uniqueProjectIds[0]!);
+    supabase = primary.supabase;
+    for (const projectId of uniqueProjectIds.slice(1)) {
+      await requireProjectMember(projectId);
+    }
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     // ✅ Use saveAttendanceRecord (not saveAttendance) to avoid:
@@ -192,7 +215,14 @@ export async function bulkSaveAttendance(
 // If attendance_points ever drifts out of sync (e.g. after a migration),
 // run this once. Normal operation doesn't need it — the trigger handles everything.
 export async function syncAllAttendancePoints(projectId?: string) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = projectId
+      ? await requireProjectMember(projectId)
+      : await requireUser());
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
 
@@ -288,7 +318,12 @@ export async function saveMeetingSchedule(
   projectId: string,
   schedule: { selectedDays: string[]; time: string; meetingLink?: string }
 ) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireProjectMember(projectId));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
   try {
     const { data, error } = await supabase
       .from("projects")
@@ -346,13 +381,21 @@ export async function createMeeting(meetingData: {
   duration_minutes?: number;
   location?: string;
   meeting_link?: string;
-  created_by: string;
+  created_by?: string;
 }) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  let user;
   try {
+    ({ supabase, user } = await requireProjectMember(meetingData.project_id));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+  try {
+    // Never trust client-supplied identity — always derive from the session.
+    const { created_by: _ignoredClientCreatedBy, ...meetingFields } = meetingData;
     const { data, error } = await supabase
       .from("meetings")
-      .insert({ ...meetingData })
+      .insert({ ...meetingFields, created_by: user.id })
       .select()
       .single();
 
@@ -375,7 +418,12 @@ export async function sendMeetingNotification(
     meetingLink?: string;
   }
 ) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireProjectMember(projectId));
+  } catch {
+    return { success: false, error: "Forbidden", sent: 0, failed: 0 };
+  }
   try {
     const { data: project, error: projectError } = await supabase
       .from("projects")

--- a/apps/codebility/app/home/overflow/actions.ts
+++ b/apps/codebility/app/home/overflow/actions.ts
@@ -2,8 +2,40 @@
 "use server";
 
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireUser } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 import sharp from 'sharp';
+
+// Ownership guard for edit/delete actions: caller must own the row, or be an admin.
+// Returns { ok } on success; { notFound } if the row is missing.
+async function assertOwnerOrAdmin(
+  supabase: Awaited<ReturnType<typeof createClientServerComponent>>,
+  userId: string,
+  table: "overflow_post" | "overflow_comments",
+  id: number,
+): Promise<{ ok: boolean; notFound?: boolean }> {
+  const { data: row, error } = await supabase
+    .from(table)
+    .select("codev_id")
+    .eq("id", id)
+    .single();
+
+  if (error || !row) {
+    return { ok: false, notFound: true };
+  }
+
+  if (row.codev_id === userId) {
+    return { ok: true };
+  }
+
+  const { data: me } = await supabase
+    .from("codev")
+    .select("role_id")
+    .eq("id", userId)
+    .single();
+
+  return { ok: me?.role_id === 1 };
+}
 
 // Question 
 export interface Question {
@@ -230,11 +262,14 @@ export interface PostQuestionData {
 
 export async function postQuestion(data: PostQuestionData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust the client-supplied authorId — derive it from the session.
+    const authorId = user.id;
 
     // Upload all files in parallel (images with compression, documents as-is)
     const fileUploadPromises = data.images.map((base64File, index) => 
-      uploadImageToStorage(supabase, base64File, data.authorId)
+      uploadImageToStorage(supabase, base64File, authorId)
         .then(url => url)
     );
 
@@ -247,7 +282,7 @@ export async function postQuestion(data: PostQuestionData) {
     const { data: insertedQuestion, error } = await supabase
       .from('overflow_post')
       .insert({
-        codev_id: data.authorId,
+        codev_id: authorId,
         title: data.title,
         question_details: data.content,
         tags: JSON.stringify(data.tags),
@@ -342,7 +377,21 @@ async function deleteImageFromStorage(supabase: any, imageUrl: string): Promise<
 
 export async function updateQuestion(data: UpdateQuestionData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Only the post owner (or an admin) may edit it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_post",
+      parseInt(data.question_id),
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Post not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
 
     // Fetch the current files from the database
     const { data: existingPost, error: fetchError } = await supabase
@@ -460,9 +509,29 @@ export async function updateQuestion(data: UpdateQuestionData) {
 
 
 export async function deletePostAndImages(postId: number) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
+    // Only the post owner (or an admin) may delete it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_post",
+      postId,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Post not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
+
     // 1. Fetch post by id to get file URLs
     const { data: post, error: fetchError } = await supabase
       .from("overflow_post")
@@ -616,10 +685,24 @@ export async function markAsSolution(
   postId: string,
 ) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
  
     const commentIdNum = parseInt(commentId);
     const postIdNum    = parseInt(postId);
+
+    // Only the post owner (or an admin) may accept/unaccept a solution.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_post",
+      postIdNum,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Post not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
  
     // Check whether this comment is already marked
     const { data: current, error: checkErr } = await supabase
@@ -670,7 +753,10 @@ export async function markAsSolution(
 // Post a new comment
 export async function postComment(data: PostCommentData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust client-supplied codev_id — derive it from the session.
+    const authorId = user.id;
 
     // Convert post_id to number for insertion
     const postIdNumber = parseInt(data.post_id);
@@ -679,7 +765,7 @@ export async function postComment(data: PostCommentData) {
     const { data: insertedComment, error } = await supabase
       .from('overflow_comments')
       .insert({
-        codev_id: data.codev_id,
+        codev_id: authorId,
         post_id: postIdNumber,
         comment: data.comment,
       })
@@ -725,7 +811,7 @@ export async function postComment(data: PostCommentData) {
       id: insertedComment.id.toString(),
       content: insertedComment.comment,
       author: {
-        id: codevData?.id || data.codev_id,
+        id: codevData?.id || authorId,
         name: codevData
           ? `${codevData.first_name} ${codevData.last_name}`.trim()
           : 'Unknown User',
@@ -799,10 +885,24 @@ export interface UpdateCommentData {
 // Add this function to your actions.ts file
 export async function updateComment(data: UpdateCommentData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
 
     // Convert comment_id to number for the query
     const commentIdNumber = parseInt(data.comment_id);
+
+    // Only the comment owner (or an admin) may edit it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_comments",
+      commentIdNumber,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Comment not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
 
     // Update the comment (no codev join to avoid RLS filtering)
     const { data: updatedComment, error } = await supabase
@@ -863,9 +963,23 @@ export async function updateComment(data: UpdateCommentData) {
 // Delete a comment
 export async function deleteComment(commentId: string) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
 
     const commentIdNumber = parseInt(commentId);
+
+    // Only the comment owner (or an admin) may delete it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_comments",
+      commentIdNumber,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Comment not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
 
     // First, get the post_id before deleting
     const { data: commentData, error: fetchError } = await supabase
@@ -920,9 +1034,12 @@ export async function deleteComment(commentId: string) {
 
 
 // Toggle like for a post
-export async function togglePostLike(postId: string, userId: string) {
+export async function togglePostLike(postId: string, _userId?: string) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust the client-supplied userId — derive it from the session.
+    const userId = user.id;
 
     // Check if user already liked this post
     const { data: existingLike, error: checkError } = await supabase
@@ -1056,9 +1173,12 @@ export async function fetchCommentLikes(userId: string, questionId: string): Pro
 }
 
 // Toggle like for a comment
-export async function toggleCommentLike(commentId: string, userId: string) {
+export async function toggleCommentLike(commentId: string, _userId?: string) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust the client-supplied userId — derive it from the session.
+    const userId = user.id;
 
     const { data: existingLike, error: checkError } = await supabase
       .from("overflow_likes")


### PR DESCRIPTION
Apply authorization guards to all mutating server actions in:
- kanban/[projectId]/[id]/actions.ts (16 actions: tasks, columns, drafts)
- kanban/[projectId]/actions.ts (createNewSprint, EditSprint)
- kanban/actions.ts (createNewBoard)
- my-team/[projectId]/actions.ts (attendance, meetings, sync)
- overflow/actions.ts (posts, comments, likes)

Key changes:
- Every mutation now checks auth BEFORE writing (not after)
- Project-scoped actions verify project_members membership
- Overflow edit/delete enforces row ownership (or admin)
- Identity (created_by, codev_id, userId) always derived from session
- Client-supplied identity params are ignored/optional
- Hoisted notification-only getUser() calls to top of kanban actions
- Added assertOwnerOrAdmin helper for overflow ownership checks
- Added project-resolution helpers for kanban task/column/board lookups

Closes the remaining half of server-action-authorization-hardening. Pairs with Week 1 (de384742) which landed auth-guard.ts + admin surface.