### PR TITLE
docs(tasks): add specs for public-dev-listing fix, full-stack skill c…

### DIFF
--- a/docs/tasks/Jordan-FS/Public-Dev-Listing-Wrong-Devs-Rendered.md
+++ b/docs/tasks/Jordan-FS/Public-Dev-Listing-Wrong-Devs-Rendered.md
@@ -1,0 +1,63 @@
+# Public Pages Render the Wrong Developers (Be a Member vs Profiles Mismatch)
+
+## Summary
+
+The public-facing developer pages disagree about which developers count as "Codevs," so they render different sets of people. The **Be a Member** page (`/codevs`) shows a stale/incorrect group of developers, while the **Profiles** page (`/profiles`) shows the correct accepted developers. Reported by Zeff: on Hire a Codev / Be a Member, "parang iba ung devs rendered" — the wrong developers appear.
+
+The root cause is that three different parts of the app use three different definitions of "accepted developer," and they no longer line up.
+
+## Background
+
+- **Accept flow** (`app/home/applicants/_service/action.ts` ~lines 277 and 307): when an admin accepts an applicant, it sets `application_status: "passed"` **and `role_id: 4`**.
+- **Be a Member** (`app/(marketing)/codevs/_components/CodevsProfiles.tsx` ~line 18): fetches devs with `getCodevs({ filters: { role_id: 10 } })` — filters on `role_id === 10`.
+- **Profiles** (`app/(marketing)/profiles/page.tsx` ~line 37): fetches devs with `getCodevs({ filters: { application_status: "passed" } })`.
+
+Because accepted developers are given `role_id: 4` but Be a Member only shows `role_id: 10`, **accepted developers never appear on Be a Member** — and whoever holds the legacy `role_id: 10` shows up instead. Profiles, filtering on `application_status: "passed"`, shows the right people. That difference is exactly the "different devs rendered" symptom.
+
+There is also a related concern worth verifying: the accept flow assigns `role_id: 4`, and the RLS migration comments (`supabase/migrations/20260219_rls_hotfix.sql`) label `role_id 4` as "Super Admin." If that mapping is accurate, every accepted applicant is being granted a Super Admin role — a privilege-escalation problem hiding behind the rendering bug. This must be confirmed against the actual `roles` table before changing anything.
+
+## Objectives
+
+- Make all public developer listings show the same, correct set of accepted developers.
+- Use a single, drift-proof definition of "accepted developer" across the pages (application status is the source of truth, since that's what the accept flow reliably sets).
+- Verify and, if needed, correct the `role_id` the accept flow assigns, so accepted developers get the intended "Codev" role — not an admin role.
+
+## Expected Behavior
+
+- Be a Member (`/codevs`) and Profiles (`/profiles`) render the same accepted developers.
+- A newly accepted developer appears on both public pages without any manual role fix-up.
+- No developer who is not accepted (applying/testing/onboarding/waitlist/denied) appears on the public pages.
+- Accepting an applicant grants the correct developer role, not an admin/super-admin role.
+
+## Acceptance Criteria
+
+- [ ] Be a Member and Profiles show an identical set of developers for the same data.
+- [ ] Accepting a test applicant makes them appear on both public pages, with no manual role edit.
+- [ ] No non-accepted developer is visible on either public page.
+- [ ] Confirmed against the `roles` table what `role_id` 4 and 10 actually are; documented in the PR.
+- [ ] The accept flow assigns the intended developer role (not Super Admin), or it's confirmed that `role_id: 4` is correct and intended.
+- [ ] No regression to the profile detail page (`/profiles/[id]`) or the admin applicant flow.
+
+## Solution Hint
+
+Treat these as advisory, not prescriptive.
+
+- Simplest, drift-proof fix for the rendering: change Be a Member to filter on the same source of truth as Profiles —
+  ```
+  // CodevsProfiles.tsx
+  getCodevs({ filters: { application_status: "passed" } })   // was { role_id: 10 }
+  ```
+  This makes "public developer" mean "accepted developer" everywhere, independent of role_id.
+- Before touching the accept flow's `role_id`, run `SELECT id, name FROM roles ORDER BY id;` and confirm what 4 and 10 are. If `role_id: 4` is an admin/super-admin role, the accept flow is over-privileging developers and should assign the real "Codev" role instead. Coordinate this change carefully — role_id drives permissions and RLS, so it affects more than these pages.
+- If the product intent is truly role-based (only devs with the Codev role are public), then fix it at the source: have the accept flow set the correct Codev role, and keep the pages consistent with that one role. Either approach is fine as long as accept-flow and page-filter agree.
+
+## Reminders
+
+- This is why the two pages differ — the accept flow and the page filters use different fields. Pick one source of truth and make everything use it.
+- Test end to end: accept a test applicant and confirm they show on both public pages.
+- The `role_id: 4` assignment is potentially a security issue — verify it before assuming it's just a rendering bug.
+
+## Instructions
+
+- Branch naming: `public-dev-listing-fix/<name>`.
+- PR should document what `role_id` 4 and 10 are, the filter change, and whether the accept-flow role assignment was corrected.

--- a/docs/tasks/Jury-FS/Server-Action-Auth-Hardening-Week2-Review-Notes.md
+++ b/docs/tasks/Jury-FS/Server-Action-Auth-Hardening-Week2-Review-Notes.md
@@ -1,0 +1,100 @@
+# Server-Action Auth Hardening — Week 2 (PR #609) Review Notes
+## Implementation review / for discussion with the author — prepared by Deo
+
+> Companion to `Server-Action-Auth-Hardening-Week2-ProjectScoped.md`.
+> PR: #609 `feat(auth): harden project-scoped & community server actions (Week 2)` by `bonfire404` (Jury).
+> Branch: `server-action-auth-hardening-week2/jury` → `dev`. 5 files, +536 / −59. Reviewed 2026-07-14 (read-only).
+
+---
+
+## Verdict
+
+**Strong PR — near-approve.** Coverage is complete across all five files and goes beyond the spec. Two hardening items to fix before merge, plus a couple of non-blocking nits.
+
+## What's done well (acknowledge this)
+
+- **Full coverage** of every mutating action in all 5 files (kanban task/column/draft, sprints, board, attendance/meetings, overflow posts/comments/likes) — including actions not in the original inventory (`updateColumnName`, `deleteColumn`, `markAsSolution`, `syncAllAttendancePoints`, `sendMeetingNotification`).
+- **`transferTaskToSprint` is now guarded** → this also closes the outstanding PR #594 kanban-transfer auth blocker.
+- **Client-supplied identity fixed everywhere:** `created_by` (tasks/drafts/meetings), `authorId` (overflow posts), and the `userId` params on `togglePostLike`/`toggleCommentLike` are now ignored and derived from the session.
+- **After-mutation `getUser` fixed:** auth is hoisted to the top of each action and the user object reused for later notification logic.
+- Sensible helper design: `getProjectIdForTask/Column/Board` + `assertProjectMembership` (admin bypass via `role_id === 1`, else `project_members`), and `assertOwnerOrAdmin` for overflow edit/delete.
+
+---
+
+## Should-fix #1 — `assertProjectMembership` fails OPEN
+
+**Where:** `kanban/[projectId]/[id]/actions.ts`, in `assertProjectMembership`.
+
+**Problem:**
+```ts
+if (!projectId) return; // skips the membership check entirely
+```
+When the project can't be resolved, the guard is skipped and only authentication is enforced. That's acceptable when the *task doesn't exist* (the mutation is a genuine no-op), but a **target that exists yet resolves no project** — an orphaned board with `project_id = null`, an RLS/permission hiccup, or a transient failed sub-query — would bypass authorization. A security guard should **fail closed**.
+
+**How to fix — distinguish "target missing" from "project unresolved":**
+Have the resolver tell the caller whether the target row existed, and deny when it existed but no project was found.
+
+```ts
+// Return a discriminated result instead of just string | null
+type ProjectResolution =
+  | { found: false }               // target row doesn't exist → mutation is a real no-op
+  | { found: true; projectId: string | null };
+
+async function getProjectIdForColumn(supabase, columnId): Promise<ProjectResolution> {
+  if (!columnId) return { found: false };
+  const { data: column } = await supabase
+    .from("kanban_columns").select("board_id").eq("id", columnId).single();
+  if (!column) return { found: false };
+  const { data: board } = await supabase
+    .from("kanban_boards").select("project_id").eq("id", column.board_id).single();
+  return { found: true, projectId: board?.project_id ?? null };
+}
+
+async function assertProjectMembership(supabase, userId, res: ProjectResolution) {
+  if (!res.found) return;                 // target truly doesn't exist → allow no-op
+  if (!res.projectId) throw new Error("Forbidden"); // exists but unresolved → DENY
+  // …admin bypass + project_members check as before…
+}
+```
+Simpler alternative if you don't want the discriminated type: keep returning `string | null`, but in `assertProjectMembership` **throw `Forbidden` on `null`** instead of returning, and only skip the check in the specific callers where a missing row is provably a no-op (or let those no-op mutations run — an unauthenticated-but-authorized call against a non-existent id is harmless once auth is already enforced).
+
+---
+
+## Should-fix #2 — `completeTask` authorizes on a client-supplied value
+
+**Where:** `kanban/[projectId]/[id]/actions.ts`, `completeTask(task: Task)`.
+
+**Problem:**
+```ts
+const guardProjectId = await getProjectIdForColumn(supabase, task.kanban_column_id);
+```
+The whole `task` object comes from the client, so `task.kanban_column_id` is attacker-controlled. Someone could pass a `kanban_column_id` from a project they *are* a member of to pass the check, while the mutation acts on other fields of the crafted object. Every other task action resolves the project from the **trusted id via a server re-fetch** — this one should too.
+
+**How to fix — resolve from the task's real id, not the passed-in column:**
+```ts
+// Instead of trusting task.kanban_column_id:
+const guardProjectId = await getProjectIdForTask(supabase, task.id);
+await assertProjectMembership(supabase, user.id, guardProjectId);
+```
+If `completeTask` genuinely needs the column for its logic, still *authorize* against `getProjectIdForTask(task.id)` (DB-truth), and treat any client-passed column as display data only. Also confirm the actual mutation targets `task.id` (server-trusted), not client-passed fields.
+
+---
+
+## Nits (non-blocking)
+
+1. **Duplicated membership logic.** `[id]/actions.ts` reimplements the admin-bypass + `project_members` check in its own `assertProjectMembership`, while `lib/server/auth-guard.ts` already has `requireProjectMember`. Two sources of truth — if the rule changes, both must be updated. Suggest exporting a `requireProjectMemberByProjectId(projectId, userId)` (or `assertProjectMembership`) from `auth-guard.ts` and reusing it here, so there's one canonical implementation.
+2. **Query depth on hot paths.** The resolver runs column→board→project as two sequential queries, plus role + membership = up to ~4 round-trips per action. On drag-heavy paths (`updateColumnPosition`, `batchUpdateTasks`) that's added latency. Could be a single joined query / RPC later. Not blocking.
+
+---
+
+## Verification checklist (before merge)
+
+- [ ] Should-fix #1 applied — guard denies when a target exists but no project resolves (fail-closed).
+- [ ] Should-fix #2 applied — `completeTask` authorizes via `getProjectIdForTask(task.id)`, not the client column.
+- [ ] Manual test: non-member session is rejected (`Forbidden`) on a cross-project task edit, column delete, sprint edit, attendance write, and overflow post/comment delete it doesn't own; the same succeed for an authorized member/admin.
+- [ ] Legitimate flows still work: kanban drag/drop, task CRUD, drafts, sprint transfer, attendance, meetings, overflow post/comment/like.
+- [ ] (Optional) membership logic de-duplicated against `auth-guard.ts`.
+
+## Ready-to-paste PR comment
+
+See the version drafted in the 2026-07-14 session (Deo posts it himself — no auto-posting to GitHub per current account caution).

--- a/docs/tasks/Kris-BE/RLS-Starter-Appointments-Guide.md
+++ b/docs/tasks/Kris-BE/RLS-Starter-Appointments-Guide.md
@@ -1,0 +1,173 @@
+# RLS Starter Guide — Table 1: `appointments` (safe, hands-on)
+## Prepared to help Kris get moving — do this ONE table first, on a local copy.
+
+Goal for this week: enable RLS on **just the `appointments` table**, tested on a local copy of the database, with zero risk to the live site. Once this one works, every other table is the same recipe with a different template.
+
+---
+
+## Part A — Set up a safe local copy (Supabase local)
+
+You'll run a full copy of the database on your own machine. Nothing you do here can touch production.
+
+### 1. Install prerequisites
+- **Docker Desktop** (Supabase local runs in Docker) — install and make sure it's running.
+- **Supabase CLI** — `npm install -g supabase` (or `scoop install supabase` on Windows).
+
+### 2. Start the local database (from the repo root)
+```bash
+cd apps/codebility
+supabase start
+```
+- First run downloads images (a few minutes). When done it prints local URLs.
+- Open **Supabase Studio** at the printed URL (usually `http://localhost:54323`) — this is your local dashboard + SQL editor.
+
+### 3. Apply all existing migrations to the local copy
+```bash
+supabase db reset
+```
+This rebuilds the local DB and runs every file in `supabase/migrations/` in order — so your local copy has the same schema (tables, the `admin_users` view, the `is_admin()` function, existing policies) as production.
+
+> If `supabase start` complains there's no config, run `supabase init` first (keep the defaults), then `supabase start`.
+
+### 4. Seed 3 test users
+Open Studio → SQL editor and run this. First check how `admin_users` decides who's an admin:
+```sql
+-- Look at the view so your admin test-user matches its rule
+select pg_get_viewdef('admin_users', true);
+select * from admin_users;
+```
+Then create test users in `codev` (adjust column names/roles to match what `admin_users` expects — e.g. if admins are `role_id = 1`, give the admin that role):
+```sql
+-- 1) ADMIN  2) NORMAL USER  3) NON-MEMBER  (use fixed UUIDs so you can impersonate them)
+insert into codev (id, first_name, last_name, email_address, role_id) values
+  ('11111111-1111-1111-1111-111111111111','Test','Admin','admin@test.local', 1),
+  ('22222222-2222-2222-2222-222222222222','Test','User','user@test.local',   4),
+  ('33333333-3333-3333-3333-333333333333','Test','Outsider','out@test.local', 4)
+on conflict (id) do nothing;
+
+-- Make sure test-admin is actually in admin_users. If admin_users reads from a
+-- separate table/flag, add the admin there too. Verify:
+select * from admin_users where id = '11111111-1111-1111-1111-111111111111';
+
+-- A couple of sample appointment rows to read back
+insert into appointments (first_name, last_name, email, status)
+values ('Alice','Client','alice@x.com','pending'), ('Bob','Client','bob@x.com','confirmed');
+```
+
+---
+
+## Part B — The starter migration (study this, then apply it locally)
+
+This mirrors the existing, tested `client_outreach` policies (`20260219_create_client_outreach_tracker.sql`). Save it as
+`supabase/migrations/20260714_enable_rls_appointments.sql` **(but test it locally first — don't push to prod yet).**
+
+```sql
+-- =============================================================================
+-- Enable RLS on the appointments table.
+-- Access model (matches the app):
+--   • The public contact form INSERTS via the service-role key (server-side),
+--     which BYPASSES RLS — so we do NOT add a public INSERT policy. That keeps
+--     random anonymous users from inserting junk directly, while the form still
+--     works. (Service role ignores RLS entirely.)
+--   • The admin management page READS and UPDATES status as the logged-in admin,
+--     so admins need SELECT + UPDATE (+ DELETE for cleanup).
+-- =============================================================================
+
+ALTER TABLE appointments ENABLE ROW LEVEL SECURITY;
+
+-- Admins can view all appointments (the admin management page)
+CREATE POLICY "Admins can view appointments"
+  ON appointments FOR SELECT
+  TO public
+  USING (auth.uid() IN (SELECT id FROM admin_users));
+
+-- Admins can update appointment status
+CREATE POLICY "Admins can update appointments"
+  ON appointments FOR UPDATE
+  TO public
+  USING      (auth.uid() IN (SELECT id FROM admin_users))
+  WITH CHECK (auth.uid() IN (SELECT id FROM admin_users));
+
+-- Admins can delete appointments
+CREATE POLICY "Admins can delete appointments"
+  ON appointments FOR DELETE
+  TO public
+  USING (auth.uid() IN (SELECT id FROM admin_users));
+```
+
+> **Important match-the-app note:** the appointments admin page gates on the `applicants` role permission, not strictly `admin_users`. If everyone who needs appointments is an admin (in `admin_users`), the above is correct. If a **non-admin role that has `applicants = true`** also needs access, swap the admin check for this and it'll match the app exactly:
+> ```sql
+> USING (EXISTS (
+>   SELECT 1 FROM codev c JOIN roles r ON r.id = c.role_id
+>   WHERE c.id = auth.uid() AND r.applicants = true
+> ))
+> ```
+> Decide which one by checking who actually opens the appointments page. When unsure, ask the team lead — don't guess.
+
+Apply it to your **local** copy:
+```bash
+supabase db reset   # re-runs all migrations incl. your new file
+```
+
+---
+
+## Part C — Test as 3 different users (do this BEFORE prod)
+
+In Studio SQL editor, "become" each test user and check what they can see. This is how you prove the policy is right:
+
+```sql
+-- ── Become the ADMIN ─────────────────────────────
+select set_config('request.jwt.claims',
+  '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}', true);
+set role authenticated;
+select count(*) from appointments;                    -- EXPECT: sees all rows ✅
+update appointments set status = 'confirmed' where true; -- EXPECT: works ✅
+reset role;
+
+-- ── Become a NORMAL USER (not admin) ─────────────
+select set_config('request.jwt.claims',
+  '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}', true);
+set role authenticated;
+select count(*) from appointments;                    -- EXPECT: 0 rows (blocked) ✅
+reset role;
+
+-- ── Become ANON (logged-out visitor) ─────────────
+set role anon;
+select count(*) from appointments;                    -- EXPECT: 0 rows (blocked) ✅
+reset role;
+```
+
+If all three behave as marked → the policy is correct.
+If the admin sees 0 → the admin isn't in `admin_users` (fix the seed / the admin check).
+If a normal user sees rows → the policy is too loose (stop, re-check).
+
+---
+
+## Part D — Undo button (nothing is permanent)
+
+Anytime, on any DB:
+```sql
+-- turn RLS back off
+ALTER TABLE appointments DISABLE ROW LEVEL SECURITY;
+-- or remove a policy
+DROP POLICY "Admins can view appointments" ON appointments;
+```
+
+---
+
+## Part E — Ship it (only after local tests pass)
+
+1. Commit the migration file.
+2. Apply to production the **same way the team normally applies migrations** (ask the team lead if unsure — do NOT hand-edit prod policies in the dashboard).
+3. Right after applying: open the real appointments admin page as an admin → confirm it still loads and status updates still work.
+4. ✅ Done — one table secured. The Supabase advisory alert for this table clears.
+
+Then repeat the exact same recipe for the next table (kanban/project tables → use the "Project/Team Data" template; save `codev` for last).
+
+---
+
+### Reminders
+- One table at a time. `appointments` first, `codev` last.
+- Policies first → enable RLS → test as 3 users → then prod.
+- Copy the templates (`RLS_POLICY_TEMPLATES.md`) — don't invent.
+- When unsure who should access a table, ask the team lead. Guessing is the only real risk here.

--- a/docs/tasks/Raineer-FE/Add-Full-Stack-Developer-Skill-Category.md
+++ b/docs/tasks/Raineer-FE/Add-Full-Stack-Developer-Skill-Category.md
@@ -1,0 +1,47 @@
+# Add "Full Stack Developer" to the Skill Category Dropdown
+
+## Summary
+
+The Skill Category dropdown in the Kanban "Add New Task" modal lists Backend Developer, Frontend Developer, Mobile Developer, Project Manager, QA Engineer, and UI/UX Designer — but is missing **Full Stack Developer**. Several team members are Full Stack developers, so tasks can't currently be categorized to them. This task adds "Full Stack Developer" as a selectable skill category.
+
+## Background
+
+The dropdown is data-driven, not hardcoded. Kanban tasks store a `skill_category_id` foreign key and read `skill_category:skill_category_id (id, name)` from the `skill_categories` table (see `app/home/kanban/[projectId]/[id]/actions.ts`). So the dropdown is populated from the `skill_categories` table — adding a row there makes the option appear automatically wherever the dropdown is rendered (task add and edit modals).
+
+## Objectives
+
+- Add a "Full Stack Developer" entry to the `skill_categories` table so it shows in the Skill Category dropdown.
+- Make sure the new category behaves like the existing ones everywhere the skill category is used (task create/edit, and the points/gamification lookups keyed on `skill_category_id`).
+
+## Expected Behavior
+
+- "Full Stack Developer" appears as an option in the Skill Category dropdown in both the Add New Task and Edit Task modals.
+- A task can be created and edited with "Full Stack Developer" selected, and it persists and displays correctly.
+- Points/leaderboard logic that reads `skill_category_id` handles the new category without errors.
+
+## Acceptance Criteria
+
+- [ ] "Full Stack Developer" is selectable in the Skill Category dropdown (add + edit task).
+- [ ] Creating a task with it saves the correct `skill_category_id` and renders the category name back.
+- [ ] Editing an existing task to "Full Stack Developer" works and persists.
+- [ ] No errors in the points/`codev_points` lookups that use `skill_category_id`.
+- [ ] Option ordering looks intentional (e.g., grouped/alphabetical with the other developer categories).
+
+## Solution Hint
+
+Treat these as advisory, not prescriptive.
+
+- Primary change is data: insert a row into `skill_categories` with `name = "Full Stack Developer"` (match the shape of the existing rows — populate any columns the others have, e.g. a `description` or default points config if present). Do it via a proper migration under `supabase/migrations/` (preferred, so it's reproducible), or directly in Supabase if the team applies data changes that way.
+- Before inserting, check the existing rows: `SELECT * FROM skill_categories ORDER BY id;` — copy whatever non-null fields the other developer categories set so the new one is consistent.
+- Confirm the dropdown truly reads from the table (fetch of `skill_categories`) and isn't also filtered/hardcoded anywhere; if there's a hardcoded list or an allow-list, add it there too.
+- If the gamification system expects per-category point weights, add the same config for the new category so task points calculate correctly.
+
+## Reminders
+
+- This is mostly a data addition; keep the new row consistent with the existing skill categories.
+- Test in both the Add and Edit task modals.
+
+## Instructions
+
+- Branch naming: `add-fullstack-skill-category/<name>`.
+- If done as a migration, name it `YYYYMMDD_add_fullstack_skill_category.sql` and note in the PR whether it also needs to be applied to the production `skill_categories` table.


### PR DESCRIPTION
…ategory, week-2 review notes, RLS starter

- Jordan-FS: public dev-listing wrong-devs fix (role_id filter mismatch)
- Raineer-FE: add Full Stack Developer skill category
- Jury-FS: week-2 auth hardening review notes
- Kris-BE: RLS starter guide (appointments-first)