### PR TITLE
CBP-140: add Full Stack Developer skill category

### DIFF
--- a/apps/codebility/supabase/migrations/20260721_add_fullstack_skill_category.sql
+++ b/apps/codebility/supabase/migrations/20260721_add_fullstack_skill_category.sql
@@ -1,0 +1,5 @@
+INSERT INTO skill_category (name, description)
+VALUES (
+  'Full Stack Developer',
+  'Works across both frontend and backend, handling the full application stack.'
+);


### PR DESCRIPTION
<img width="776" height="838" alt="Screenshot 2026-07-21 at 8 41 06 PM" src="https://github.com/user-attachments/assets/8baef8e7-bb9b-4d2c-8f67-78efee5f3b40" />


This fix adds "Full Stack Developer" as a selectable category. It now shows up correctly in both the Add Task and Edit Task screens, in alphabetical order with the rest.