### PR TITLE
Public dev listing fix/jordan

### DIFF
--- a/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
+++ b/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
@@ -15,7 +15,7 @@ export const revalidate = 0;
 
 export default async function CodevsProfiles() {
   const [{ data: allCodevs, error }] = await Promise.all([
-    getCodevs({ filters: { role_id: 10 } }), // show only Codevs with role_id 10 which is Codev
+    getCodevs({ filters: { application_status: "passed" } }), // show only accepted Codevs (application_status is the source of truth)
   ]);
 
   if (error) {

--- a/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
+++ b/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
@@ -15,7 +15,7 @@ export const revalidate = 0;
 
 export default async function CodevsProfiles() {
   const [{ data: allCodevs, error }] = await Promise.all([
-    getCodevs({ filters: { application_status: "passed" } }), // show only accepted Codevs (application_status is the source of truth)
+    getCodevs({ filters: { application_status: "passed" } }), // show only accepted Codevs 
   ]);
 
   if (error) {

--- a/apps/codebility/app/home/applicants/_service/action.ts
+++ b/apps/codebility/app/home/applicants/_service/action.ts
@@ -275,7 +275,7 @@ export async function acceptApplicantAction(applicantId: string) {
             .from("codev")
             .update({
                 application_status: "passed",
-                role_id: 4,
+                role_id: 10,
                 date_joined: new Date().toISOString(),
                 updated_at: new Date().toISOString()
             })
@@ -305,7 +305,7 @@ export async function multipleAcceptApplicantAction(applicantIds: string[]) {
             .from("codev")
             .update({
                 application_status: "passed",
-                role_id: 4,
+                role_id: 10,
                 date_joined: new Date().toISOString(),
                 updated_at: new Date().toISOString()
             })

--- a/apps/codebility/supabase/migrations/20260716_fix_accepted_dev_role_id.sql
+++ b/apps/codebility/supabase/migrations/20260716_fix_accepted_dev_role_id.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- Fix role_id for accepted developers
+--
+-- The accept flow was incorrectly assigning role_id: 4 (Super Admin/Intern)
+-- instead of role_id: 10 (Codev). This migration:
+--   1. Fixes existing accepted devs who have role_id 4 → set them to role_id 10
+--   2. Does NOT touch role_id 1 (Admin) users — they stay as Admin
+--   3. Only affects rows where application_status = 'passed'
+--
+-- Role ID mapping (confirmed from codebase usage):
+--   1  = Admin
+--   4  = Super Admin / Intern (over-privileged, was assigned by mistake in accept flow)
+--   5  = Mentor
+--   7  = Applicant
+--   10 = Codev (intended role for accepted developers)
+-- =============================================================================
+
+-- Fix existing accepted developers who were given the wrong role
+UPDATE public.codev
+SET role_id = 10,
+    updated_at = NOW()
+WHERE application_status = 'passed'
+  AND role_id = 4;
+
+-- Log what was changed
+SELECT 'Fixed role_id for accepted devs' AS action,
+       COUNT(*) AS rows_affected
+FROM public.codev
+WHERE application_status = 'passed'
+  AND role_id = 10;


### PR DESCRIPTION
## Summary
Fix accepted developer role assignment and standardize public developer listings.

## Changes
- Updated `CodevsProfiles.tsx` to filter developers using `application_status = "passed"`.
- Standardized `/codevs` and `/profiles` to use `application_status` as the source of truth.
- Fixed applicant acceptance flow to assign `role_id = 10 (Codev)` instead of `role_id = 4 (Intern)`.
- Added SQL migration (`20260716_fix_accepted_dev_role_id.sql`) to update legacy records:
  - Updated accepted developers with `application_status = 'passed'` from `role_id = 4` to `role_id = 10`.

## Role Mapping
-role_id 1 : Admin (Administrator permissions)
-role_id 2 : HR (Human Resources)
-role_id 3 : Marketing (Marketing team)
-ole_id 4 : Intern (Previously mistakenly assigned during applicant acceptance flow)
-role_id 5 : Mentor (Mentor role)
-role_id 6 : Guest (Guest user access)
-role_id 7 : Applicant (Default status assigned on sign-up)
-role_id 10 : Codev (Intended role for accepted developers)

<img width="381" height="722" alt="Screenshot 2026-07-22 153646" src="https://github.com/user-attachments/assets/57234ebe-8918-444b-b93d-7547b53dd306" />
<img width="542" height="505" alt="Screenshot 2026-07-22 153940" src="https://github.com/user-attachments/assets/f6030d21-82a3-4da4-a014-979ede45dbb1" />
<img width="1535" height="816" alt="Screenshot 2026-07-22 154137" src="https://github.com/user-attachments/assets/c433da0b-494e-4718-a67f-221bb54d360e" />
