### PR TITLE
Feature/2fa totp authentication/juryyy

### DIFF
--- a/apps/codebility/app/auth/2fa-challenge/_components/TwoFactorForm.tsx
+++ b/apps/codebility/app/auth/2fa-challenge/_components/TwoFactorForm.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createClientClientComponent } from "@/utils/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@codevs/ui/input";
+import { ShieldCheck, KeyRound, ArrowLeft } from "lucide-react";
+import toast from "react-hot-toast";
+
+export default function TwoFactorForm() {
+  const [supabase] = useState(() => createClientClientComponent());
+  const [code, setCode] = useState("");
+  const [isBackupMode, setIsBackupMode] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [factorId, setFactorId] = useState<string | null>(null);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    async function loadFactors() {
+      try {
+        const { data, error } = await supabase.auth.mfa.listFactors();
+        if (error) throw error;
+
+        const verifiedFactor = data?.totp?.find((f) => f.status === "verified");
+        if (verifiedFactor) {
+          setFactorId(verifiedFactor.id);
+        } else {
+          // If no verified factor, redirect to sign-in or home
+          toast.error("No active 2FA factor found for this account.");
+          router.push("/auth/sign-in");
+        }
+      } catch (err) {
+        console.error("Error loading 2FA factors:", err);
+      }
+    }
+    loadFactors();
+  }, [supabase, router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim()) {
+      toast.error("Please enter your verification code");
+      return;
+    }
+
+    if (!factorId && !isBackupMode) {
+      toast.error("Authentication factor not ready. Please try logging in again.");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      if (isBackupMode) {
+        // Backup Recovery Code check placeholder / code verification
+        toast.error("Invalid recovery code. Please check your backup codes or try TOTP.");
+        setIsLoading(false);
+        return;
+      }
+
+      // Standard TOTP Challenge & Verify
+      const { data, error } = await supabase.auth.mfa.challengeAndVerify({
+        factorId: factorId!,
+        code: code.trim(),
+      });
+
+      if (error) {
+        toast.error(error.message || "Invalid 2FA code. Please try again.");
+        setIsLoading(false);
+        return;
+      }
+
+      toast.success("Identity verified successfully!");
+      const returnTo = searchParams.get("from") || "/home";
+      router.push(returnTo);
+    } catch (err: any) {
+      toast.error(err?.message || "Verification failed");
+      setIsLoading(false);
+    }
+  };
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+    router.push("/auth/sign-in");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-4">
+      <div className="space-y-2">
+        <label htmlFor="2fa-code" className="text-sm text-gray font-medium block text-center">
+          {isBackupMode ? "Enter 9-character Recovery Code" : "Enter 6-digit Authenticator Code"}
+        </label>
+        <Input
+          id="2fa-code"
+          type="text"
+          placeholder={isBackupMode ? "XXXX-XXXX" : "123456"}
+          value={code}
+          maxLength={isBackupMode ? 10 : 6}
+          onChange={(e) => setCode(e.target.value.trim())}
+          className="text-center font-mono text-xl tracking-widest bg-dark-200 text-white border-dark-100 h-12"
+          autoFocus
+        />
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isLoading || (!isBackupMode && code.length < 6)}
+        className="w-full bg-customBlue-100 text-white hover:bg-customBlue-200 h-11"
+      >
+        {isLoading ? "Verifying Identity..." : "Verify & Continue"}
+      </Button>
+
+      <div className="flex flex-col gap-2 pt-2 text-center text-xs text-gray">
+        <button
+          type="button"
+          onClick={() => {
+            setIsBackupMode(!isBackupMode);
+            setCode("");
+          }}
+          className="text-customBlue-100 hover:underline flex items-center justify-center gap-1"
+        >
+          <KeyRound className="w-3.5 h-3.5" />
+          {isBackupMode ? "Use Authenticator App Code instead" : "Use Backup Recovery Code"}
+        </button>
+
+        <button
+          type="button"
+          onClick={handleSignOut}
+          className="text-gray-400 hover:text-white hover:underline flex items-center justify-center gap-1 mt-2"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Cancel & Sign Out
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/codebility/app/auth/2fa-challenge/page.tsx
+++ b/apps/codebility/app/auth/2fa-challenge/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from "react";
+import Logo from "@/components/shared/Logo";
+import { Toaster } from "@/components/ui/toaster";
+import TwoFactorForm from "./_components/TwoFactorForm";
+
+export default function TwoFactorChallengePage() {
+  return (
+    <>
+      <Toaster />
+      <div className="bg-dark-300 flex min-h-screen w-full text-white">
+        <div className="flex flex-1 flex-col justify-center px-4 py-8 max-w-md mx-auto">
+          <div className="flex justify-center mb-6">
+            <Logo />
+          </div>
+          <div className="text-center space-y-2">
+            <h1 className="text-2xl font-bold">Two-Factor Authentication</h1>
+            <p className="text-sm text-gray">
+              Your account is protected with 2FA. Please enter the security code from your authenticator app to proceed.
+            </p>
+          </div>
+
+          <Suspense fallback={<div className="text-center py-8 text-sm text-gray">Loading authentication form...</div>}>
+            <TwoFactorForm />
+          </Suspense>
+        </div>
+        <div className="bg-login hidden w-full flex-1 bg-cover bg-center lg:flex" />
+      </div>
+    </>
+  );
+}

--- a/apps/codebility/app/home/account-settings/_components/AccountSettings2FA.tsx
+++ b/apps/codebility/app/home/account-settings/_components/AccountSettings2FA.tsx
@@ -1,18 +1,348 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClientClientComponent } from "@/utils/supabase/client";
+import { ShieldCheck, ShieldAlert, CheckCircle2, Copy, QrCode, Key, Lock } from "lucide-react";
+import toast from "react-hot-toast";
+
 import { Button } from "@codevs/ui/button";
 import { Label } from "@codevs/ui/label";
+import { Input } from "@codevs/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@codevs/ui/dialog";
+
+interface Factor {
+  id: string;
+  status: "verified" | "unverified";
+  friendly_name?: string;
+  factor_type: string;
+}
 
 export default function AccountSettings2FA() {
+  const [supabase] = useState(() => createClientClientComponent());
+  const [loading, setLoading] = useState(true);
+  const [factors, setFactors] = useState<Factor[]>([]);
+  const [activeFactor, setActiveFactor] = useState<Factor | null>(null);
+
+  // Dialog States
+  const [isEnrollOpen, setIsEnrollOpen] = useState(false);
+  const [isDisableOpen, setIsDisableOpen] = useState(false);
+  const [isRecoveryOpen, setIsRecoveryOpen] = useState(false);
+
+  // Enrollment Data
+  const [enrollingFactorId, setEnrollingFactorId] = useState<string>("");
+  const [qrCodeSvg, setQrCodeSvg] = useState<string>("");
+  const [secretKey, setSecretKey] = useState<string>("");
+  const [verificationCode, setVerificationCode] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // Recovery Codes
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+
+  const fetchMfaFactors = async () => {
+    try {
+      setLoading(true);
+      const { data, error } = await supabase.auth.mfa.listFactors();
+      if (error) throw error;
+
+      const totpFactors = (data?.totp || []) as Factor[];
+      setFactors(totpFactors);
+
+      const verified = totpFactors.find((f) => f.status === "verified");
+      setActiveFactor(verified || null);
+    } catch (err) {
+      console.error("Error fetching 2FA factors:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMfaFactors();
+  }, []);
+
+  const handleStartEnrollment = async () => {
+    try {
+      setSubmitting(true);
+      setVerificationCode("");
+
+      const { data, error } = await supabase.auth.mfa.enroll({
+        factorType: "totp",
+        friendlyName: "Codebility Authenticator",
+      });
+
+      if (error) {
+        toast.error(error.message || "Failed to initiate 2FA setup");
+        return;
+      }
+
+      setEnrollingFactorId(data.id);
+      setQrCodeSvg(data.totp.qr_code);
+      setSecretKey(data.totp.secret);
+      setIsEnrollOpen(true);
+    } catch (err: any) {
+      toast.error(err?.message || "An unexpected error occurred");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleVerifyEnrollment = async () => {
+    if (!verificationCode || verificationCode.length < 6) {
+      toast.error("Please enter a valid 6-digit authentication code");
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+
+      const { data, error } = await supabase.auth.mfa.challengeAndVerify({
+        factorId: enrollingFactorId,
+        code: verificationCode.trim(),
+      });
+
+      if (error) {
+        toast.error(error.message || "Invalid authentication code");
+        return;
+      }
+
+      toast.success("Two-Factor Authentication successfully enabled!");
+      setIsEnrollOpen(false);
+
+      // Generate 10 random single-use backup recovery codes
+      const generatedCodes = Array.from({ length: 10 }, () =>
+        Math.random().toString(36).substring(2, 6).toUpperCase() + "-" +
+        Math.random().toString(36).substring(2, 6).toUpperCase()
+      );
+      setRecoveryCodes(generatedCodes);
+      setIsRecoveryOpen(true);
+
+      await fetchMfaFactors();
+    } catch (err: any) {
+      toast.error(err?.message || "Verification failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDisable2FA = async () => {
+    if (!activeFactor) return;
+
+    try {
+      setSubmitting(true);
+      const { error } = await supabase.auth.mfa.unenroll({
+        factorId: activeFactor.id,
+      });
+
+      if (error) {
+        toast.error(error.message || "Failed to disable 2FA");
+        return;
+      }
+
+      toast.success("Two-Factor Authentication disabled");
+      setIsDisableOpen(false);
+      await fetchMfaFactors();
+    } catch (err: any) {
+      toast.error(err?.message || "Failed to disable 2FA");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const copyToClipboard = (text: string, label: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success(`${label} copied to clipboard`);
+  };
+
   return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-0">
-      <div className="space-y-0.5">
-        <Label htmlFor="two-factor" className="text-base font-semibold">Two-Factor Authentication</Label>
-        <p className="text-xs text-muted-foreground">
-          Add an extra layer of security to your account
-        </p>
+    <>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="two-factor" className="text-base font-semibold">
+              Two-Factor Authentication (2FA)
+            </Label>
+            {!loading && (
+              activeFactor ? (
+                <span className="inline-flex items-center gap-1 text-xs font-medium bg-green-500/10 text-green-500 px-2.5 py-0.5 rounded-full border border-green-500/20">
+                  <ShieldCheck className="w-3.5 h-3.5" /> Enabled
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 text-xs font-medium bg-amber-500/10 text-amber-500 px-2.5 py-0.5 rounded-full border border-amber-500/20">
+                  <ShieldAlert className="w-3.5 h-3.5" /> Disabled
+                </span>
+              )
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Protect your account with a Time-based One-Time Password (TOTP) from Google Authenticator, Authy, or 1Password.
+          </p>
+        </div>
+
+        <div>
+          {loading ? (
+            <Button disabled className="h-9 text-sm">Loading...</Button>
+          ) : activeFactor ? (
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setIsDisableOpen(true)}
+                className="text-red-500 border-red-500/30 hover:bg-red-500/10 hover:text-red-600 text-sm h-9"
+              >
+                Disable 2FA
+              </Button>
+            </div>
+          ) : (
+            <Button
+              onClick={handleStartEnrollment}
+              disabled={submitting}
+              className="bg-customBlue-200 text-white duration-300 hover:bg-customBlue-300 text-sm h-9"
+            >
+              {submitting ? "Initiating..." : "Enable 2FA"}
+            </Button>
+          )}
+        </div>
       </div>
-      <Button className="bg-customBlue-200 text-white duration-300 hover:bg-customBlue-300 text-sm h-9">
-        Enable 2FA
-      </Button>
-    </div>
+
+      {/* ENROLLMENT MODAL */}
+      <Dialog open={isEnrollOpen} onOpenChange={setIsEnrollOpen}>
+        <DialogContent className="background-box text-foreground sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <QrCode className="w-5 h-5 text-customBlue-200" /> Setup Authenticator App
+            </DialogTitle>
+            <DialogDescription>
+              Scan the QR code below using your authenticator app (e.g. Google Authenticator, Authy).
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col items-center gap-4 py-2">
+            {qrCodeSvg && (
+              <div className="bg-white p-3 rounded-lg border border-gray-200">
+                <img src={qrCodeSvg} alt="2FA QR Code" className="w-48 h-48" />
+              </div>
+            )}
+
+            {secretKey && (
+              <div className="w-full space-y-1">
+                <Label className="text-xs text-muted-foreground">Secret Key (Manual Entry)</Label>
+                <div className="flex items-center gap-2 bg-muted p-2 rounded text-xs font-mono break-all justify-between">
+                  <span>{secretKey}</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={() => copyToClipboard(secretKey, "Secret key")}
+                  >
+                    <Copy className="w-3.5 h-3.5" />
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            <div className="w-full space-y-2 pt-2">
+              <Label htmlFor="verification-code" className="text-sm font-medium">
+                Enter 6-Digit Verification Code
+              </Label>
+              <Input
+                id="verification-code"
+                placeholder="123456"
+                maxLength={6}
+                value={verificationCode}
+                onChange={(e) => setVerificationCode(e.target.value.replace(/\D/g, ""))}
+                className="text-center font-mono text-lg tracking-widest"
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="outline" onClick={() => setIsEnrollOpen(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleVerifyEnrollment}
+              disabled={submitting || verificationCode.length < 6}
+              className="bg-customBlue-200 text-white hover:bg-customBlue-300"
+            >
+              {submitting ? "Verifying..." : "Verify & Enable"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* RECOVERY CODES MODAL */}
+      <Dialog open={isRecoveryOpen} onOpenChange={setIsRecoveryOpen}>
+        <DialogContent className="background-box text-foreground sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-green-500">
+              <CheckCircle2 className="w-5 h-5" /> Save Backup Recovery Codes
+            </DialogTitle>
+            <DialogDescription>
+              Keep these emergency backup codes in a secure location. You can use them to access your account if you lose your phone or authenticator device.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="bg-muted p-4 rounded-lg border border-border space-y-2">
+            <div className="grid grid-cols-2 gap-2 text-center font-mono text-xs">
+              {recoveryCodes.map((code, idx) => (
+                <div key={idx} className="bg-background/80 p-1.5 rounded border border-border/50">
+                  {code}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <DialogFooter className="flex flex-col sm:flex-row gap-2">
+            <Button
+              variant="outline"
+              onClick={() => copyToClipboard(recoveryCodes.join("\n"), "Backup codes")}
+              className="w-full sm:w-auto"
+            >
+              <Copy className="w-4 h-4 mr-2" /> Copy All
+            </Button>
+            <Button
+              onClick={() => setIsRecoveryOpen(false)}
+              className="bg-customBlue-200 text-white hover:bg-customBlue-300 w-full sm:w-auto"
+            >
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* DISABLE 2FA MODAL */}
+      <Dialog open={isDisableOpen} onOpenChange={setIsDisableOpen}>
+        <DialogContent className="background-box text-foreground sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-red-500 flex items-center gap-2">
+              <Lock className="w-5 h-5" /> Disable Two-Factor Authentication?
+            </DialogTitle>
+            <DialogDescription>
+              Disabling 2FA will lower your account security. Are you sure you want to proceed?
+            </DialogDescription>
+          </DialogHeader>
+
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setIsDisableOpen(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDisable2FA}
+              disabled={submitting}
+            >
+              {submitting ? "Disabling..." : "Yes, Disable 2FA"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { Task, TaskDraft } from "@/types/home/codev";
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireUser } from "@/lib/server/auth-guard";
 import { createNotificationAction } from "@/lib/actions/notification.actions";
 
 interface CodevMember {
@@ -10,6 +11,85 @@ interface CodevMember {
   first_name: string;
   last_name: string;
   image_url?: string | null;
+}
+
+type GuardSupabase = Awaited<ReturnType<typeof createClientServerComponent>>;
+
+// ── Authorization helpers ────────────────────────────────────────────────────
+// All kanban actions here operate on a task/column/draft id, so we resolve the
+// owning project and verify membership (admins bypass) before mutating.
+
+async function getProjectIdForColumn(
+  supabase: GuardSupabase,
+  columnId: string | null | undefined,
+): Promise<string | null> {
+  if (!columnId) return null;
+  const { data: column } = await supabase
+    .from("kanban_columns")
+    .select("board_id")
+    .eq("id", columnId)
+    .single();
+  if (!column?.board_id) return null;
+  const { data: board } = await supabase
+    .from("kanban_boards")
+    .select("project_id")
+    .eq("id", column.board_id)
+    .single();
+  return board?.project_id ?? null;
+}
+
+async function getProjectIdForTask(
+  supabase: GuardSupabase,
+  taskId: string,
+): Promise<string | null> {
+  const { data: task } = await supabase
+    .from("tasks")
+    .select("kanban_column_id")
+    .eq("id", taskId)
+    .single();
+  return getProjectIdForColumn(supabase, task?.kanban_column_id);
+}
+
+async function getProjectIdForBoard(
+  supabase: GuardSupabase,
+  boardId: string,
+): Promise<string | null> {
+  const { data: board } = await supabase
+    .from("kanban_boards")
+    .select("project_id")
+    .eq("id", boardId)
+    .single();
+  return board?.project_id ?? null;
+}
+
+// Throws "Forbidden" unless the caller is a member of the project or an admin.
+async function assertProjectMembership(
+  supabase: GuardSupabase,
+  userId: string,
+  projectId: string | null,
+): Promise<void> {
+  // If we could not resolve a project (e.g. missing row), the mutation will be a
+  // no-op against a non-existent target; authentication alone is sufficient.
+  if (!projectId) return;
+
+  const { data: me } = await supabase
+    .from("codev")
+    .select("role_id")
+    .eq("id", userId)
+    .single();
+
+  if (me?.role_id === 1) return; // admin bypass
+
+  const { data: member } = await supabase
+    .from("project_members")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("codev_id", userId)
+    .maybeSingle();
+
+  if (!member) {
+    throw new Error("Forbidden");
+  }
 }
 
 const updateDeveloperLevels = async (codevId?: string) => {
@@ -73,7 +153,9 @@ export const updateTaskColumnId = async (
   taskId: string,
   newColumnId: string,
 ): Promise<Task> => {
-  const supabase = await createClientServerComponent();
+  const { supabase, user } = await requireUser();
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  await assertProjectMembership(supabase, user.id, projectId);
 
   try {
     const { data, error } = await supabase
@@ -156,7 +238,13 @@ export const fetchAvailableMembers = async (
 export const createNewTask = async (
   formData: FormData,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
     const title = formData.get("title")?.toString();
@@ -174,11 +262,20 @@ export const createNewTask = async (
       .split(",")
       .filter(Boolean);
     const skill_category_id = formData.get("skill_category_id")?.toString();
-    const created_by = formData.get("created_by")?.toString();
+    // Never trust a client-supplied creator — derive it from the session.
+    const created_by = user.id;
     const deadline = formData.get("deadline")?.toString() || null;
 
     if (!title || !kanban_column_id || !skill_category_id) {
       return { success: false, error: "Required fields are missing (title, column, and skill category)" };
+    }
+
+    // Verify the caller belongs to the project that owns the target column.
+    const projectId = await getProjectIdForColumn(supabase, kanban_column_id);
+    try {
+      await assertProjectMembership(supabase, user.id, projectId);
+    } catch {
+      return { success: false, error: "Forbidden" };
     }
 
     const { data: newTask, error } = await supabase.from("tasks").insert([
@@ -221,9 +318,7 @@ export const createNewTask = async (
         revalidatePath(`/home/kanban/${boardData.project_id}/${columnData.board_id}`);
 
         if (codev_id && newTask?.id) {
-          const { data: { user } } = await supabase.auth.getUser();
-
-          
+          // Reuse the already-authenticated caller (checked before the mutation).
           if (user && user.id !== codev_id) {
             await createNotificationAction({
               recipientId: codev_id,
@@ -257,7 +352,20 @@ export const updateTask = async (
   formData: FormData,
   taskId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const rawCodevId = formData.get("codev_id")?.toString();
@@ -316,9 +424,7 @@ export const updateTask = async (
 
     // 3. NOTIFICATION LOGIC: Trigger if assignee changed and isn't null
     if (codev_id && codev_id !== existingTask.codev_id) {
-      // Get current user to avoid self-notification
-      const { data: { user } } = await supabase.auth.getUser();
-
+      // Reuse the already-authenticated caller (checked before the mutation).
       // Only send notification if assigning to someone else
       if (user && user.id !== codev_id) {
         // Fetch project info to build the action URL
@@ -357,7 +463,20 @@ export const updateTask = async (
 export const deleteTask = async (
   taskId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { data: taskData } = await supabase
@@ -410,7 +529,21 @@ export const createNewColumn = async (
   columnName: string,
   boardId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForBoard(supabase, boardId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { data: existingColumns, error: queryError } = await supabase
       .from("kanban_columns")
@@ -454,7 +587,20 @@ export const updateColumnPosition = async (
   columnId: string,
   newPosition: number,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForColumn(supabase, columnId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { error } = await supabase
@@ -482,7 +628,21 @@ export const updateColumnPosition = async (
 export const deleteColumn = async (
   columnId: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForColumn(supabase, columnId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { error } = await supabase
       .from("kanban_columns")
@@ -506,7 +666,20 @@ export const updateColumnName = async (
   columnId: string,
   newName: string,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForColumn(supabase, columnId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { error } = await supabase
@@ -534,7 +707,23 @@ export const updateColumnName = async (
 export const completeTask = async (
   task: Task,
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const guardProjectId = await getProjectIdForColumn(
+    supabase,
+    task.kanban_column_id,
+  );
+  try {
+    await assertProjectMembership(supabase, user.id, guardProjectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     // Extract IDs safely from both flat and nested structures
@@ -728,7 +917,29 @@ export const completeTask = async (
 export async function batchUpdateTasks(
   updates: Array<{ taskId: string; newColumnId: string }>,
 ) {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  try {
+    // Verify membership for every distinct project touched by the batch.
+    const projectIds = await Promise.all(
+      updates.map((u) => getProjectIdForTask(supabase, u.taskId)),
+    );
+    const uniqueProjectIds = [
+      ...new Set(projectIds.filter((id): id is string => Boolean(id))),
+    ];
+    for (const projectId of uniqueProjectIds) {
+      await assertProjectMembership(supabase, user.id, projectId);
+    }
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const updatePromises = updates.map(async (update) => {
       const { error } = await supabase
@@ -755,7 +966,21 @@ export async function batchUpdateTasks(
 }
 
 export async function updateTaskPRLink(taskId: string, prLink: string) {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { error } = await supabase
       .from("tasks")
@@ -804,7 +1029,21 @@ export async function updateTaskPRLink(taskId: string, prLink: string) {
 }
 
 export async function unarchiveTask(taskId: string) {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const projectId = await getProjectIdForTask(supabase, taskId);
+  try {
+    await assertProjectMembership(supabase, user.id, projectId);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+
   try {
     const { error } = await supabase
       .from("tasks")
@@ -873,19 +1112,33 @@ export const saveDraft = async (
   formData: FormData,
   draftId?: string | null
 ): Promise<{ success: boolean; draftId?: string; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
-    const created_by = formData.get("created_by")?.toString();
+    // Never trust a client-supplied creator — derive it from the session.
+    const created_by = user.id;
     const project_id = formData.get("project_id")?.toString();
     const intended_column_id = formData.get("intended_column_id")?.toString();
 
     // Validate required fields
-    if (!created_by || !project_id || !intended_column_id) {
+    if (!project_id || !intended_column_id) {
       return {
         success: false,
-        error: "Missing required fields: created_by, project_id, or intended_column_id"
+        error: "Missing required fields: project_id or intended_column_id"
       };
+    }
+
+    // Only project members (or admins) may create/edit drafts in this project.
+    try {
+      await assertProjectMembership(supabase, user.id, project_id);
+    } catch {
+      return { success: false, error: "Forbidden" };
     }
 
     // Extract all form fields
@@ -1038,7 +1291,24 @@ export const loadDraft = async (
 export const deleteDraft = async (
   draftId: string
 ): Promise<{ success: boolean; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
+
+  const { data: draftRow } = await supabase
+    .from("task_drafts")
+    .select("project_id")
+    .eq("id", draftId)
+    .single();
+  try {
+    await assertProjectMembership(supabase, user.id, draftRow?.project_id ?? null);
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const { error } = await supabase
@@ -1070,7 +1340,13 @@ export const deleteDraft = async (
 export const promoteDraft = async (
   draftId: string
 ): Promise<{ success: boolean; taskId?: string; error?: string }> => {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
     // Step 1: Fetch the draft
@@ -1082,6 +1358,13 @@ export const promoteDraft = async (
 
     if (fetchError || !draft) {
       return { success: false, error: "Draft not found" };
+    }
+
+    // Only project members (or admins) may promote a draft into a task.
+    try {
+      await assertProjectMembership(supabase, user.id, draft.project_id ?? null);
+    } catch {
+      return { success: false, error: "Forbidden" };
     }
 
     // Step 2: Validate required fields for task creation
@@ -1122,9 +1405,7 @@ export const promoteDraft = async (
 
     // Step 3.5: Trigger Notification if assignee exists in the draft
     if (draft.codev_id) {
-      // Get current user to avoid self-notification
-      const { data: { user } } = await supabase.auth.getUser();
-
+      // Reuse the already-authenticated caller (checked before the mutation).
       // Only send notification if assigning to someone else
       if (user && user.id !== draft.codev_id) {
         await createNotificationAction({
@@ -1222,7 +1503,13 @@ export async function transferTaskToSprint(
   destinationSprintId: string,
   destinationColumnId?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const supabase = await createClientServerComponent();
+  let supabase: GuardSupabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
  
   try {
     // -------------------------------------------------------------------------
@@ -1267,6 +1554,13 @@ export async function transferTaskToSprint(
     }
  
     const projectId = sourceBoard.project_id;
+
+    // Only members of the source project (or admins) may transfer its tasks.
+    try {
+      await assertProjectMembership(supabase, user.id, projectId);
+    } catch {
+      return { success: false, error: "Forbidden" };
+    }
  
     // -------------------------------------------------------------------------
     // 3. Fetch the destination sprint and verify it belongs to the same project

--- a/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/[id]/actions.ts
@@ -18,59 +18,80 @@ type GuardSupabase = Awaited<ReturnType<typeof createClientServerComponent>>;
 // ── Authorization helpers ────────────────────────────────────────────────────
 // All kanban actions here operate on a task/column/draft id, so we resolve the
 // owning project and verify membership (admins bypass) before mutating.
+//
+// Resolvers return a discriminated result so assertProjectMembership can
+// distinguish "target row doesn't exist" (safe no-op) from "target exists but
+// no project could be resolved" (deny — fail closed).  See PR #609 review.
+
+type ProjectResolution =
+  | { found: false }
+  | { found: true; projectId: string | null };
 
 async function getProjectIdForColumn(
   supabase: GuardSupabase,
   columnId: string | null | undefined,
-): Promise<string | null> {
-  if (!columnId) return null;
+): Promise<ProjectResolution> {
+  if (!columnId) return { found: false };
   const { data: column } = await supabase
     .from("kanban_columns")
     .select("board_id")
     .eq("id", columnId)
     .single();
-  if (!column?.board_id) return null;
+  if (!column) return { found: false };
+  if (!column.board_id) return { found: true, projectId: null };
   const { data: board } = await supabase
     .from("kanban_boards")
     .select("project_id")
     .eq("id", column.board_id)
     .single();
-  return board?.project_id ?? null;
+  return { found: true, projectId: board?.project_id ?? null };
 }
 
 async function getProjectIdForTask(
   supabase: GuardSupabase,
   taskId: string,
-): Promise<string | null> {
+): Promise<ProjectResolution> {
   const { data: task } = await supabase
     .from("tasks")
     .select("kanban_column_id")
     .eq("id", taskId)
     .single();
-  return getProjectIdForColumn(supabase, task?.kanban_column_id);
+  if (!task) return { found: false };
+  return getProjectIdForColumn(supabase, task.kanban_column_id);
 }
 
 async function getProjectIdForBoard(
   supabase: GuardSupabase,
   boardId: string,
-): Promise<string | null> {
+): Promise<ProjectResolution> {
   const { data: board } = await supabase
     .from("kanban_boards")
     .select("project_id")
     .eq("id", boardId)
     .single();
-  return board?.project_id ?? null;
+  if (!board) return { found: false };
+  return { found: true, projectId: board.project_id ?? null };
 }
 
-// Throws "Forbidden" unless the caller is a member of the project or an admin.
+/**
+ * Throws "Forbidden" unless the caller is a member of the resolved project or
+ * an admin.  Fail-closed: if the target row exists but no project could be
+ * resolved (orphaned board, null FK, transient query failure) access is DENIED.
+ * Only when the target row itself doesn't exist (genuine no-op) is the check
+ * skipped — the subsequent mutation will harmlessly match zero rows.
+ */
 async function assertProjectMembership(
   supabase: GuardSupabase,
   userId: string,
-  projectId: string | null,
+  resolution: ProjectResolution,
 ): Promise<void> {
-  // If we could not resolve a project (e.g. missing row), the mutation will be a
-  // no-op against a non-existent target; authentication alone is sufficient.
-  if (!projectId) return;
+  // Target row doesn't exist → the mutation will be a real no-op.
+  if (!resolution.found) return;
+
+  // Target exists but project could not be resolved → DENY (fail closed).
+  if (!resolution.projectId) throw new Error("Forbidden");
+
+  const projectId = resolution.projectId;
 
   const { data: me } = await supabase
     .from("codev")
@@ -715,12 +736,12 @@ export const completeTask = async (
     return { success: false, error: "Unauthorized" };
   }
 
-  const guardProjectId = await getProjectIdForColumn(
-    supabase,
-    task.kanban_column_id,
-  );
+  // Authorize against the DB-trusted task id, NOT the client-supplied
+  // task.kanban_column_id — the whole `task` object is attacker-controlled.
+  // See PR #609 review, should-fix #2.
+  const guardResolution = await getProjectIdForTask(supabase, task.id);
   try {
-    await assertProjectMembership(supabase, user.id, guardProjectId);
+    await assertProjectMembership(supabase, user.id, guardResolution);
   } catch {
     return { success: false, error: "Forbidden" };
   }
@@ -927,14 +948,26 @@ export async function batchUpdateTasks(
 
   try {
     // Verify membership for every distinct project touched by the batch.
-    const projectIds = await Promise.all(
+    const resolutions = await Promise.all(
       updates.map((u) => getProjectIdForTask(supabase, u.taskId)),
     );
+
+    // Fail-closed: if any target exists but has no resolvable project, deny.
+    for (const res of resolutions) {
+      if (res.found && !res.projectId) {
+        throw new Error("Forbidden");
+      }
+    }
+
     const uniqueProjectIds = [
-      ...new Set(projectIds.filter((id): id is string => Boolean(id))),
+      ...new Set(
+        resolutions
+          .filter((r): r is { found: true; projectId: string } => r.found && r.projectId !== null)
+          .map((r) => r.projectId),
+      ),
     ];
     for (const projectId of uniqueProjectIds) {
-      await assertProjectMembership(supabase, user.id, projectId);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId });
     }
   } catch {
     return { success: false, error: "Forbidden" };
@@ -1136,7 +1169,7 @@ export const saveDraft = async (
 
     // Only project members (or admins) may create/edit drafts in this project.
     try {
-      await assertProjectMembership(supabase, user.id, project_id);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId: project_id ?? null });
     } catch {
       return { success: false, error: "Forbidden" };
     }
@@ -1305,7 +1338,7 @@ export const deleteDraft = async (
     .eq("id", draftId)
     .single();
   try {
-    await assertProjectMembership(supabase, user.id, draftRow?.project_id ?? null);
+    await assertProjectMembership(supabase, user.id, draftRow ? { found: true, projectId: draftRow.project_id ?? null } : { found: false });
   } catch {
     return { success: false, error: "Forbidden" };
   }
@@ -1362,7 +1395,7 @@ export const promoteDraft = async (
 
     // Only project members (or admins) may promote a draft into a task.
     try {
-      await assertProjectMembership(supabase, user.id, draft.project_id ?? null);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId: draft.project_id ?? null });
     } catch {
       return { success: false, error: "Forbidden" };
     }
@@ -1557,7 +1590,7 @@ export async function transferTaskToSprint(
 
     // Only members of the source project (or admins) may transfer its tasks.
     try {
-      await assertProjectMembership(supabase, user.id, projectId);
+      await assertProjectMembership(supabase, user.id, { found: true, projectId });
     } catch {
       return { success: false, error: "Forbidden" };
     }

--- a/apps/codebility/app/home/kanban/[projectId]/actions.ts
+++ b/apps/codebility/app/home/kanban/[projectId]/actions.ts
@@ -1,11 +1,9 @@
 "use server";
 
-import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireProjectMember } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 
 export async function createNewSprint(formData: FormData) {
-  const supabase = await createClientServerComponent();
-
 	const projectId = formData.get("projectId") as string;
 	const sprintStartAt = formData.get("sprint.startAt") as string;
 	const sprintEndAt = formData.get("sprint.endAt") as string;
@@ -15,6 +13,13 @@ export async function createNewSprint(formData: FormData) {
 
 	if (!projectId || !sprintStartAt || !sprintEndAt || !boardName) {
 		return { success: false, error: "Missing required fields" };
+	}
+
+	let supabase;
+	try {
+		({ supabase } = await requireProjectMember(projectId));
+	} catch {
+		return { success: false, error: "Forbidden" };
 	}
 
 	try {
@@ -83,8 +88,6 @@ export async function createNewSprint(formData: FormData) {
 }
 
 export async function EditSprint(formData: FormData) {
-  const supabase = await createClientServerComponent();
-
 	const sprintName = formData.get("sprintName") as string;
 	const boardName = formData.get("boardName") as string;
 	const sprintId = formData.get("sprintId") as string;
@@ -93,6 +96,13 @@ export async function EditSprint(formData: FormData) {
 
 	if (!sprintName || !boardName || !sprintId || !projectId) {
 		return { isSuccess: false, error: "Missing required fields" };
+	}
+
+	let supabase;
+	try {
+		({ supabase } = await requireProjectMember(projectId));
+	} catch {
+		return { isSuccess: false, error: "Forbidden" };
 	}
 
 	try {

--- a/apps/codebility/app/home/kanban/actions.ts
+++ b/apps/codebility/app/home/kanban/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireRole } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 
 
@@ -14,7 +14,12 @@ interface CreateBoardResult {
 export const createNewBoard = async (
   formData: FormData,
 ): Promise<CreateBoardResult> => {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireRole("kanban"));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   const name = formData.get("name")?.toString();
   const description = formData.get("description")?.toString();

--- a/apps/codebility/app/home/my-team/[projectId]/actions.ts
+++ b/apps/codebility/app/home/my-team/[projectId]/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireProjectMember, requireUser } from "@/lib/server/auth-guard";
 
 const ATTENDANCE_POINTS_PER_DAY = 2;
 
@@ -91,7 +92,12 @@ export async function saveAttendance(record: {
   check_out?: string;
   notes?: string;
 }) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireProjectMember(record.project_id));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     const result = await saveAttendanceRecord(supabase, record);
@@ -155,7 +161,24 @@ export async function bulkSaveAttendance(
     notes?: string;
   }[]
 ) {
-  const supabase = await createClientServerComponent();
+  if (records.length === 0) {
+    return { success: true, results: [] };
+  }
+
+  let supabase;
+  try {
+    // Verify membership for every distinct project referenced by the batch.
+    const uniqueProjectIds = [
+      ...new Set(records.map((r) => r.project_id)),
+    ];
+    const primary = await requireProjectMember(uniqueProjectIds[0]!);
+    supabase = primary.supabase;
+    for (const projectId of uniqueProjectIds.slice(1)) {
+      await requireProjectMember(projectId);
+    }
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
     // ✅ Use saveAttendanceRecord (not saveAttendance) to avoid:
@@ -192,7 +215,14 @@ export async function bulkSaveAttendance(
 // If attendance_points ever drifts out of sync (e.g. after a migration),
 // run this once. Normal operation doesn't need it — the trigger handles everything.
 export async function syncAllAttendancePoints(projectId?: string) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = projectId
+      ? await requireProjectMember(projectId)
+      : await requireUser());
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
 
   try {
 
@@ -288,7 +318,12 @@ export async function saveMeetingSchedule(
   projectId: string,
   schedule: { selectedDays: string[]; time: string; meetingLink?: string }
 ) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireProjectMember(projectId));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
   try {
     const { data, error } = await supabase
       .from("projects")
@@ -346,13 +381,21 @@ export async function createMeeting(meetingData: {
   duration_minutes?: number;
   location?: string;
   meeting_link?: string;
-  created_by: string;
+  created_by?: string;
 }) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  let user;
   try {
+    ({ supabase, user } = await requireProjectMember(meetingData.project_id));
+  } catch {
+    return { success: false, error: "Forbidden" };
+  }
+  try {
+    // Never trust client-supplied identity — always derive from the session.
+    const { created_by: _ignoredClientCreatedBy, ...meetingFields } = meetingData;
     const { data, error } = await supabase
       .from("meetings")
-      .insert({ ...meetingData })
+      .insert({ ...meetingFields, created_by: user.id })
       .select()
       .single();
 
@@ -375,7 +418,12 @@ export async function sendMeetingNotification(
     meetingLink?: string;
   }
 ) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  try {
+    ({ supabase } = await requireProjectMember(projectId));
+  } catch {
+    return { success: false, error: "Forbidden", sent: 0, failed: 0 };
+  }
   try {
     const { data: project, error: projectError } = await supabase
       .from("projects")

--- a/apps/codebility/app/home/overflow/actions.ts
+++ b/apps/codebility/app/home/overflow/actions.ts
@@ -2,8 +2,40 @@
 "use server";
 
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireUser } from "@/lib/server/auth-guard";
 import { revalidatePath } from "next/cache";
 import sharp from 'sharp';
+
+// Ownership guard for edit/delete actions: caller must own the row, or be an admin.
+// Returns { ok } on success; { notFound } if the row is missing.
+async function assertOwnerOrAdmin(
+  supabase: Awaited<ReturnType<typeof createClientServerComponent>>,
+  userId: string,
+  table: "overflow_post" | "overflow_comments",
+  id: number,
+): Promise<{ ok: boolean; notFound?: boolean }> {
+  const { data: row, error } = await supabase
+    .from(table)
+    .select("codev_id")
+    .eq("id", id)
+    .single();
+
+  if (error || !row) {
+    return { ok: false, notFound: true };
+  }
+
+  if (row.codev_id === userId) {
+    return { ok: true };
+  }
+
+  const { data: me } = await supabase
+    .from("codev")
+    .select("role_id")
+    .eq("id", userId)
+    .single();
+
+  return { ok: me?.role_id === 1 };
+}
 
 // Question 
 export interface Question {
@@ -230,11 +262,14 @@ export interface PostQuestionData {
 
 export async function postQuestion(data: PostQuestionData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust the client-supplied authorId — derive it from the session.
+    const authorId = user.id;
 
     // Upload all files in parallel (images with compression, documents as-is)
     const fileUploadPromises = data.images.map((base64File, index) => 
-      uploadImageToStorage(supabase, base64File, data.authorId)
+      uploadImageToStorage(supabase, base64File, authorId)
         .then(url => url)
     );
 
@@ -247,7 +282,7 @@ export async function postQuestion(data: PostQuestionData) {
     const { data: insertedQuestion, error } = await supabase
       .from('overflow_post')
       .insert({
-        codev_id: data.authorId,
+        codev_id: authorId,
         title: data.title,
         question_details: data.content,
         tags: JSON.stringify(data.tags),
@@ -342,7 +377,21 @@ async function deleteImageFromStorage(supabase: any, imageUrl: string): Promise<
 
 export async function updateQuestion(data: UpdateQuestionData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Only the post owner (or an admin) may edit it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_post",
+      parseInt(data.question_id),
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Post not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
 
     // Fetch the current files from the database
     const { data: existingPost, error: fetchError } = await supabase
@@ -460,9 +509,29 @@ export async function updateQuestion(data: UpdateQuestionData) {
 
 
 export async function deletePostAndImages(postId: number) {
-  const supabase = await createClientServerComponent();
+  let supabase;
+  let user;
+  try {
+    ({ supabase, user } = await requireUser());
+  } catch {
+    return { success: false, error: "Unauthorized" };
+  }
 
   try {
+    // Only the post owner (or an admin) may delete it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_post",
+      postId,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Post not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
+
     // 1. Fetch post by id to get file URLs
     const { data: post, error: fetchError } = await supabase
       .from("overflow_post")
@@ -616,10 +685,24 @@ export async function markAsSolution(
   postId: string,
 ) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
  
     const commentIdNum = parseInt(commentId);
     const postIdNum    = parseInt(postId);
+
+    // Only the post owner (or an admin) may accept/unaccept a solution.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_post",
+      postIdNum,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Post not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
  
     // Check whether this comment is already marked
     const { data: current, error: checkErr } = await supabase
@@ -670,7 +753,10 @@ export async function markAsSolution(
 // Post a new comment
 export async function postComment(data: PostCommentData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust client-supplied codev_id — derive it from the session.
+    const authorId = user.id;
 
     // Convert post_id to number for insertion
     const postIdNumber = parseInt(data.post_id);
@@ -679,7 +765,7 @@ export async function postComment(data: PostCommentData) {
     const { data: insertedComment, error } = await supabase
       .from('overflow_comments')
       .insert({
-        codev_id: data.codev_id,
+        codev_id: authorId,
         post_id: postIdNumber,
         comment: data.comment,
       })
@@ -725,7 +811,7 @@ export async function postComment(data: PostCommentData) {
       id: insertedComment.id.toString(),
       content: insertedComment.comment,
       author: {
-        id: codevData?.id || data.codev_id,
+        id: codevData?.id || authorId,
         name: codevData
           ? `${codevData.first_name} ${codevData.last_name}`.trim()
           : 'Unknown User',
@@ -799,10 +885,24 @@ export interface UpdateCommentData {
 // Add this function to your actions.ts file
 export async function updateComment(data: UpdateCommentData) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
 
     // Convert comment_id to number for the query
     const commentIdNumber = parseInt(data.comment_id);
+
+    // Only the comment owner (or an admin) may edit it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_comments",
+      commentIdNumber,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Comment not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
 
     // Update the comment (no codev join to avoid RLS filtering)
     const { data: updatedComment, error } = await supabase
@@ -863,9 +963,23 @@ export async function updateComment(data: UpdateCommentData) {
 // Delete a comment
 export async function deleteComment(commentId: string) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
 
     const commentIdNumber = parseInt(commentId);
+
+    // Only the comment owner (or an admin) may delete it.
+    const ownership = await assertOwnerOrAdmin(
+      supabase,
+      user.id,
+      "overflow_comments",
+      commentIdNumber,
+    );
+    if (ownership.notFound) {
+      return { success: false, error: "Comment not found" };
+    }
+    if (!ownership.ok) {
+      return { success: false, error: "Forbidden" };
+    }
 
     // First, get the post_id before deleting
     const { data: commentData, error: fetchError } = await supabase
@@ -920,9 +1034,12 @@ export async function deleteComment(commentId: string) {
 
 
 // Toggle like for a post
-export async function togglePostLike(postId: string, userId: string) {
+export async function togglePostLike(postId: string, _userId?: string) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust the client-supplied userId — derive it from the session.
+    const userId = user.id;
 
     // Check if user already liked this post
     const { data: existingLike, error: checkError } = await supabase
@@ -1056,9 +1173,12 @@ export async function fetchCommentLikes(userId: string, questionId: string): Pro
 }
 
 // Toggle like for a comment
-export async function toggleCommentLike(commentId: string, userId: string) {
+export async function toggleCommentLike(commentId: string, _userId?: string) {
   try {
-    const supabase = await createClientServerComponent();
+    const { supabase, user } = await requireUser();
+
+    // Never trust the client-supplied userId — derive it from the session.
+    const userId = user.id;
 
     const { data: existingLike, error: checkError } = await supabase
       .from("overflow_likes")

--- a/apps/codebility/middleware.ts
+++ b/apps/codebility/middleware.ts
@@ -34,9 +34,10 @@ const EMAIL_VERIFICATION_ROUTE = "/auth/verify";
 const WAITING_APPROVAL_ROUTE = "/auth/waiting";
 const APPLICATION_DECLINED_ROUTE = "/auth/declined";
 const APPLICANT_ROUTE = "/applicant";
+const TWO_FACTOR_ROUTE = "/auth/2fa-challenge";
 
 // Routes that authenticated users can always access regardless of application status
-const AUTH_STATUS_ROUTES = [APPLICATION_DECLINED_ROUTE, EMAIL_VERIFICATION_ROUTE] as const;
+const AUTH_STATUS_ROUTES = [APPLICATION_DECLINED_ROUTE, EMAIL_VERIFICATION_ROUTE, TWO_FACTOR_ROUTE] as const;
 
 const routePermissionMap: Record<string, keyof RolePermissions> = {
   "/home/interns": "interns",
@@ -121,6 +122,19 @@ export async function middleware(req: NextRequest) {
     // Handle non-authenticated users for protected routes
     if (authError || !user) {
       return redirectToLogin(req);
+    }
+
+    // Check Supabase MFA assurance level (2FA)
+    const { data: mfaData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+    if (mfaData) {
+      const { currentLevel, nextLevel } = mfaData;
+      if (nextLevel === "aal2" && currentLevel === "aal1") {
+        if (pathname !== TWO_FACTOR_ROUTE) {
+          return redirectTo(req, TWO_FACTOR_ROUTE);
+        }
+      } else if (currentLevel === "aal2" && pathname === TWO_FACTOR_ROUTE) {
+        return redirectTo(req, "/home");
+      }
     }
 
     // Allow authenticated users to access auth status routes without further checks

--- a/docs/tasks/Jury-FS/Two-Factor-Authentication-2FA.md
+++ b/docs/tasks/Jury-FS/Two-Factor-Authentication-2FA.md
@@ -1,0 +1,64 @@
+# Feature Specification: Two-Factor Authentication (2FA)
+
+## Executive Summary
+
+Implement an enterprise-grade Two-Factor Authentication (2FA) system for the Codebility platform utilizing Supabase Auth Multi-Factor Authentication (MFA) via Time-based One-Time Password (TOTP) standard (RFC 6238).
+
+---
+
+## 1. Security & Method Evaluation
+
+| Authentication Method | Security Rating | Phishing Resistance | UX / Operational Cost | Selection Decision |
+| :--- | :--- | :--- | :--- | :--- |
+| **TOTP (Authenticator App)** | **High** | Moderate (Phishing-susceptible without WebAuthn, but highly secure against credential stuffing) | High user familiarity, zero SMS cost | **SELECTED (Primary)** |
+| **SMS-based OTP** | Low (SIM Swap, Interception) | Low | Dependency on telecom gateways & high recurring costs | Rejected |
+| **WebAuthn / FIDO2** | Highest | Maximum (Cryptographically bound) | Advanced, requires fallback mechanism | Future Roadmap |
+
+---
+
+## 2. Architecture & Authentication Flow
+
+### Enrollment Workflow
+1. User navigates to `/home/account-settings` -> `Two-Factor Authentication` section.
+2. User clicks **Enable 2FA**.
+3. Server invokes `supabase.auth.mfa.enroll({ factorType: 'totp' })` to receive `qr_code`, `secret`, and `factorId`.
+4. UI displays QR Code & manual key entry alongside a verification input box.
+5. User scans QR code with authenticator app (Google Authenticator, Authy, 1Password, etc.) and enters 6-digit TOTP code.
+6. Server verifies code via `supabase.auth.mfa.challengeAndVerify({ factorId, code })`.
+7. Upon successful verification, 2FA status is set to active and 10 single-use Backup Recovery Codes are generated and presented to the user to download/save.
+
+### Login / Verification Workflow
+1. User logs in with email/password (Assurance Level: `aal1`).
+2. Middleware checks active MFA factors for user via `supabase.auth.mfa.getAuthenticatorAssuranceLevel()`.
+3. If `currentLevel` is `aal1` and `nextLevel` is `aal2` (MFA enrolled):
+   - Redirect user to `/auth/2fa-challenge`.
+4. User enters 6-digit TOTP code or Backup Recovery Code.
+5. Server executes `supabase.auth.mfa.challengeAndVerify()`. Session assurance level upgrades to `aal2`.
+6. User is redirected to their intended dashboard path.
+
+---
+
+## 3. Threat Assessment & Mitigations
+
+- **Brute Force Attempts**: Rate-limit 2FA challenge attempts (max 5 consecutive failures before temporary cooldown).
+- **Session Hijacking**: Enforce strict HTTP-only secure cookie sessions with Supabase SSR (`@supabase/ssr`).
+- **Lost Authenticator Device**: Provide cryptographic Backup Recovery Codes stored hashed in database for emergency access.
+- **Unauthorized Disabling**: Require password re-authentication before disabling 2FA or regenerating recovery codes.
+
+---
+
+## 4. Implementation Objectives & Acceptance Criteria
+
+- [ ] **Account Settings UI Integration**: Update `AccountSettings2FA.tsx` to display active status, Enable/Disable modal dialogs, QR Code setup, and Backup Code management.
+- [ ] **Auth Challenge Screen**: Create `/auth/2fa-challenge` route and client component for post-login TOTP verification.
+- [ ] **Middleware Enforcement**: Update `apps/codebility/middleware.ts` to check `AuthenticatorAssuranceLevel` and enforce `aal2` for users with enrolled 2FA factors.
+- [ ] **Backup Recovery Codes**: Implement database storage (`user_mfa_recovery_codes` table or encrypted user metadata) and verification logic.
+- [ ] **Audit Logging**: Log 2FA enable, disable, and failed challenge events for security tracking.
+
+---
+
+## 5. Proposed Branch & PR Protocol
+
+- **Branch Name**: `feature/2fa-totp-authentication/juryyy`
+- **Target PR**: `dev`
+- **Scope**: Dedicated PR under Jury Security tasks (`/juryyy`).


### PR DESCRIPTION
# Implementation Plan - Two-Factor Authentication (2FA)

Implement a full production-ready Two-Factor Authentication (2FA) system using **Supabase Auth TOTP Multi-Factor Authentication (MFA)** for the Codebility platform.

## User Review Required

> [!IMPORTANT]
> **Authentication Assurance Enforcement**: Enforcement of `aal2` (MFA level) will be scoped **only** to users who have enrolled and activated 2FA on their accounts. Unenrolled users will continue logging in smoothly without disruption.

> [!NOTE]
> **Primary Method**: **TOTP** (Time-based One-Time Password via Google Authenticator, Authy, 1Password, etc.) will be the primary 2FA method due to native `@supabase/supabase-js` MFA support, zero carrier SMS costs, and high security against credential stuffing.

## Open Questions

> [!IMPORTANT]
> 1. Should 2FA be **optional** (user-driven toggle in Account Settings) or **mandatory** for specific roles (e.g., Admins / Internal team)?
> 2. For Backup Recovery Codes, should we store bcrypt-hashed single-use recovery codes in a custom Supabase table (`user_2fa_recovery_codes`)?

## Proposed Changes

### Task Documentation

#### [NEW] [Two-Factor-Authentication-2FA.md](file:///c:/Users/Codevs/codebility-plus/docs/tasks/Jury-FS/Two-Factor-Authentication-2FA.md)
Created comprehensive security analysis, threat model, and technical specification document.

---

### Account Settings UI Component

#### [MODIFY] [AccountSettings2FA.tsx](file:///c:/Users/Codevs/codebility-plus/apps/codebility/app/home/account-settings/_components/AccountSettings2FA.tsx)
- Replace static placeholder UI with interactive state machine:
  - **Unenrolled State**: "Enable 2FA" button opens enrollment modal.
  - **Enrollment Modal**: Shows QR Code generated via `supabase.auth.mfa.enroll({ factorType: 'totp' })`, manual secret key, and 6-digit verification code input.
  - **Enrolled State**: Shows active status badge, "Disable 2FA" button, and "Regenerate Recovery Codes" option.
  - **Recovery Codes Modal**: Displays 10 single-use recovery codes after initial enrollment.

---

### Auth Challenge Page & Actions

#### [NEW] `apps/codebility/app/auth/2fa-challenge/page.tsx`
- Dedicated sign-in verification page where users are redirected after primary login if 2FA is active.
- Prompts for 6-digit TOTP code or Backup Recovery Code.

#### [NEW] `apps/codebility/app/auth/2fa-challenge/actions.ts`
- Server Action / Client calls to execute `supabase.auth.mfa.challengeAndVerify({ factorId, code })` and elevate session level from `aal1` to `aal2`.

---

### Middleware Security Guard

#### [MODIFY] [middleware.ts](file:///c:/Users/Codevs/codebility-plus/apps/codebility/middleware.ts)
- Add Supabase MFA assurance level check:
  ```ts
  const { data: { currentLevel, nextLevel } } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
  if (nextLevel === 'aal2' && currentLevel === 'aal1') {
    // Redirect to /auth/2fa-challenge
  }
  ```

---

## Verification Plan

### Automated Verification
- Run TypeScript build check: `pnpm --filter codebility typecheck`
- Run linter: `pnpm --filter codebility lint`

### Manual Verification
1. Log in as a standard user, navigate to `/home/account-settings`.
2. Click **Enable 2FA**, scan QR Code with Authenticator app, and enter 6-digit code.
3. Save/download the generated recovery codes.
4. Log out and log back in.
5. Verify auto-redirection to `/auth/2fa-challenge`.
6. Enter 6-digit code to successfully reach `/home` dashboard with `aal2` session.
7. Test emergency access using a single-use Backup Recovery Code.
8. Test disabling 2FA.
