### PR TITLE
fix(leaderboard): restore all-time points to the codev_points ledger

### DIFF
--- a/apps/codebility/app/api/project-leaderboard/route.ts
+++ b/apps/codebility/app/api/project-leaderboard/route.ts
@@ -35,8 +35,87 @@ export async function GET(request: NextRequest) {
 
     let processedLeaders: ProjectLeader[] = [];
 
-    // The tasks table is the single source of truth for points to ensure consistency
-    // across all-time, monthly, and weekly leaderboards.
+    // All-time totals come from the codev_points ledger via project membership, NOT from
+    // the tasks table. codev_points is append-only; the tasks table is mutable, so
+    // recomputing all-time totals from tasks silently drops points whose originating task
+    // was later deleted, un-archived, or had its skill_category cleared. Time-ranged views
+    // below still derive from tasks, where the approval date is the whole point.
+    if (timeFilter === "all") {
+      const { data: rawData, error: allTimeError } = await supabase
+        .from("projects")
+        .select(`
+          id,
+          name,
+          project_members(
+            codev_id,
+            codev_points(
+              points,
+              skill_category:skill_category_id(name)
+            )
+          )
+        `);
+
+      if (allTimeError) {
+        console.error("Error fetching all-time project leaderboard:", allTimeError);
+        return NextResponse.json(
+          { error: "Failed to fetch leaderboard data", details: allTimeError.message },
+          { status: 500 }
+        );
+      }
+
+      const allTimeMap = new Map<string, {
+        project_id: string;
+        project_name: string;
+        total_points: number;
+        members: Set<string>;
+        skill_breakdown: Record<string, number>;
+      }>();
+
+      rawData?.forEach((project: any) => {
+        const projectId = project.id;
+        if (!projectId) return;
+
+        if (!allTimeMap.has(projectId)) {
+          allTimeMap.set(projectId, {
+            project_id: projectId,
+            project_name: project.name || "Unknown Project",
+            total_points: 0,
+            members: new Set(),
+            skill_breakdown: {}
+          });
+        }
+        const projectData = allTimeMap.get(projectId)!;
+
+        project.project_members?.forEach((member: any) => {
+          if (member.codev_id) projectData.members.add(member.codev_id);
+          member.codev_points?.forEach((point: any) => {
+            const skillName = point.skill_category?.name || "Other";
+            const val = point.points || 0;
+            projectData.total_points += val;
+            projectData.skill_breakdown[skillName] = (projectData.skill_breakdown[skillName] || 0) + val;
+          });
+        });
+      });
+
+      processedLeaders = Array.from(allTimeMap.values())
+        .map(p => ({
+          project_id: p.project_id,
+          project_name: p.project_name,
+          total_points: p.total_points,
+          member_count: p.members.size,
+          skill_breakdown: p.skill_breakdown
+        }))
+        .filter(p => p.total_points > 0)
+        .sort((a, b) => b.total_points - a.total_points)
+        .slice(0, limit);
+
+      return NextResponse.json({
+        leaders: processedLeaders,
+        totalCount: processedLeaders.length
+      });
+    }
+
+    // Weekly/monthly are derived from approved tasks within the requested window.
     let query = supabase
       .from("tasks")
       .select(`
@@ -53,7 +132,7 @@ export async function GET(request: NextRequest) {
     if (timeFilter === "weekly") {
       const { startDate, endDate } = getWeekRange();
       query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
-    } else if (timeFilter === "monthly") {
+    } else {
       const { startDate, endDate } = getMonthRange();
       query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
     }

--- a/apps/codebility/app/api/technical-leaderboard/route.ts
+++ b/apps/codebility/app/api/technical-leaderboard/route.ts
@@ -35,8 +35,73 @@ export async function GET(request: NextRequest) {
 
     let processedLeaders: TechnicalLeader[] = [];
 
-    // The tasks table is the single source of truth for points to ensure consistency
-    // across all-time, monthly, and weekly leaderboards.
+    // All-time totals come from the codev_points ledger, NOT from the tasks table.
+    //
+    // codev_points is append-only: points are added when a task is approved and are
+    // never removed. The tasks table is mutable, so recomputing all-time totals from it
+    // silently drops every point whose originating task was later deleted, un-archived,
+    // or had its skill_category cleared — which is what caused the all-time leaderboard
+    // to under-report. Time-ranged views below still derive from tasks, where the
+    // approval date is the whole point of the query.
+    if (timeFilter === "all") {
+      const { data: rawPoints, error: pointsError } = await supabase
+        .from("codev_points")
+        .select(`
+          codev_id,
+          points,
+          created_at,
+          codev:codev_id!inner(first_name),
+          skill_category:skill_category_id!inner(name)
+        `)
+        .eq("skill_category.name", category)
+        .not("codev.first_name", "is", null);
+
+      if (pointsError) {
+        console.error("Error fetching all-time technical leaderboard:", pointsError);
+        return NextResponse.json(
+          { error: "Failed to fetch leaderboard data", details: pointsError.message },
+          { status: 500 }
+        );
+      }
+
+      // codev_points holds one row per (codev, skill category), but aggregate defensively
+      // in case duplicate rows exist for a pair.
+      const allTimeMap = new Map<string, TechnicalLeader>();
+
+      rawPoints?.forEach((entry: any) => {
+        const userId = entry.codev_id;
+        if (!userId) return;
+
+        const points = entry.points || 0;
+        const existing = allTimeMap.get(userId);
+
+        if (existing) {
+          existing.total_points += points;
+          if (entry.created_at && entry.created_at > existing.latest_update) {
+            existing.latest_update = entry.created_at;
+          }
+        } else {
+          allTimeMap.set(userId, {
+            codev_id: userId,
+            first_name: entry.codev?.first_name || "Unknown",
+            total_points: points,
+            latest_update: entry.created_at || new Date(0).toISOString()
+          });
+        }
+      });
+
+      processedLeaders = Array.from(allTimeMap.values())
+        .filter(leader => leader.total_points > 0)
+        .sort((a, b) => b.total_points - a.total_points)
+        .slice(0, limit);
+
+      return NextResponse.json({
+        leaders: processedLeaders,
+        totalCount: processedLeaders.length
+      });
+    }
+
+    // Weekly/monthly are derived from approved tasks within the requested window.
     let query = supabase
       .from("tasks")
       .select(`
@@ -53,7 +118,7 @@ export async function GET(request: NextRequest) {
     if (timeFilter === "weekly") {
       const { startDate, endDate } = getWeekRange();
       query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
-    } else if (timeFilter === "monthly") {
+    } else {
       const { startDate, endDate } = getMonthRange();
       query = query.gte("approved_at", startDate.toISOString()).lte("approved_at", endDate.toISOString());
     }


### PR DESCRIPTION
## Summary

The all-time leaderboard has been under-reporting points in production. This restores it.

`ce3a3d4e` (PR #597) switched **every** time filter to recompute points from the `tasks` table. That works for weekly/monthly, but not for all-time:

- `codev_points` is an **append-only ledger** — points are added when a task is approved and are never removed.
- `tasks` is **mutable**.

So recomputing all-time totals from `tasks` silently dropped every point whose originating task was later deleted, un-archived, or had its `skill_category` cleared or changed. Only tasks currently satisfying `is_archive = true` **and** a non-null matching `skill_category_id` still counted.

The change dates from 2026-05-23 but only reached production in the **#610 release on 2026-07-14**, which is why it is being reported now.

## Changes

Restores the `timeFilter === "all"` branch in both routes to read `codev_points`:

- `app/api/technical-leaderboard/route.ts`
- `app/api/project-leaderboard/route.ts`

**Weekly and monthly are unchanged.** They keep deriving from approved tasks via `approved_at` and the Monday-start `getWeekRange`/`getMonthRange` helpers — that part of `ce3a3d4e` was a genuine improvement over the previous `updated_at` + Sunday-start logic and is deliberately preserved.

Not touched, because they were never affected:
- `my-team/[projectId]/leaderboard/actions.ts` — time-ranged only, no all-time view
- `soft-skills-leaderboard` — reads `attendance_points`/`profile_points` via RPC

## No data migration required

`codev_points` never stopped being written (`kanban/[projectId]/[id]/actions.ts:820-850` updates it on every approval). This was a read-path regression only, so the original totals are intact and correct numbers return as soon as this deploys.

## Test plan

- [x] `pnpm typecheck` — **181 errors in 49 files both with and without this change** (verified by stashing and re-running). Zero new errors; neither leaderboard route appears in the error list. The 181 are pre-existing and unrelated.
- [ ] Verify against prod data that the ledger totals match what the owner expects:

```sql
-- What the leaderboard showed after the regression
SELECT c.first_name, SUM(t.points) AS tasks_points
FROM tasks t
JOIN skill_category sc ON sc.id = t.skill_category_id
JOIN codev c ON c.id = t.codev_id
WHERE sc.name = 'FE' AND t.is_archive = true
GROUP BY c.first_name ORDER BY tasks_points DESC LIMIT 10;

-- What this PR restores
SELECT c.first_name, SUM(cp.points) AS ledger_points
FROM codev_points cp
JOIN skill_category sc ON sc.id = cp.skill_category_id
JOIN codev c ON c.id = cp.codev_id
WHERE sc.name = 'FE'
GROUP BY c.first_name ORDER BY ledger_points DESC LIMIT 10;
```

- [ ] Check Technical (all categories), Projects, and Soft Skills tabs across All Time / Monthly / Weekly.

## Note on reaching production

Production deploys from `master`. Merging this to `dev` does **not** fix the live site — it needs a `dev`→`master` release afterwards.

## Follow-up (not in this PR)

The underlying split-brain remains: all-time reads `codev_points` while weekly/monthly read `tasks`, and those two can drift. Reconciling them properly — rather than patching either side — deserves its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
