### PR TITLE
fix(codevs): show accepted developers on Be a Member

### DIFF
--- a/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
+++ b/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
@@ -15,7 +15,11 @@ export const revalidate = 0;
 
 export default async function CodevsProfiles() {
   const [{ data: allCodevs, error }] = await Promise.all([
-    getCodevs({ filters: { role_id: 10 } }), // show only Codevs with role_id 10 which is Codev
+    // Accepted developers are identified by application_status, not by role_id.
+    // The accept flow sets application_status "passed" while role_id tracks the
+    // Intern → Codev → Mentor progression, so filtering on role_id 10 hid every
+    // newly accepted developer. /profiles already uses this same filter.
+    getCodevs({ filters: { application_status: "passed" } }),
   ]);
 
   if (error) {


### PR DESCRIPTION
## Summary

Fixes the wrong developers rendering on Be a Member (`/codevs`), reported by Zeff.

The page filtered on `role_id: 10`:

```ts
getCodevs({ filters: { role_id: 10 } }) // show only Codevs with role_id 10 which is Codev
```

but the accept flow (`app/home/applicants/_service/action.ts:278,308`) sets `role_id: 4`. Accepted developers therefore never appeared on the page, and whoever still held the legacy `role_id: 10` showed up instead.

`application_status` is the reliable signal. The accept flow always sets it to `"passed"`, while `role_id` tracks the Intern → Codev → Mentor progression and changes as a developer advances. `/profiles` already filters on it, so both public pages now read from one source of truth and cannot drift apart again.

## Scope

One line, one file. The existing post-filter is untouched:

```ts
getPrioritizedAndFilteredCodevs(codevsArray, { activeStatus: ["active"] }, true)
```

That still removes admins (`role_id 1`), `failed` and `applying` codevs, then narrows to active — so nobody who should be hidden becomes visible. The change only widens the fetch from one role to all accepted developers.

## Relationship to #613

This is the filter half of #613, split out so the reported bug can ship on its own.

#613 also changes the accept flow from `role_id: 4` to `10` and adds a migration promoting every existing Intern to Codev. That part needs more discussion — role 4 is **Intern**, confirmed against the `roles` table, and the accept flow assigning it is correct. Changing it would collapse the Intern → Codev progression and make `acceptPromotionToCodev` unreachable, and the migration has no rollback.

None of that is needed to fix what was reported, so it stays in #613 for that discussion. Credit to @pamplonajp45-eng — the filter fix is his, this PR just separates it out so it isn't blocked.

## Test plan

- [x] `pnpm typecheck` — **182 errors in 50 files both with and without this change** (verified by stashing and re-running). Zero new errors, none in `CodevsProfiles.tsx`.
- [ ] `/codevs` and `/profiles` show a consistent set of accepted developers.
- [ ] No admin, failed, applying or inactive codev appears on `/codevs`.
- [ ] Accept a test applicant and confirm they appear on both pages with no manual role edit.

## Reaching production

Production deploys from `master`, so this needs a `dev`→`master` release after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
