### PR TITLE
In house filter sort/jordan

### DIFF
--- a/apps/codebility/app/home/in-house/_components/table/table-filters.tsx
+++ b/apps/codebility/app/home/in-house/_components/table/table-filters.tsx
@@ -60,8 +60,11 @@ export function TableFilters({ filters, onFilterChange }: TableFiltersProps) {
       if (error) {
         console.error("Failed to fetch projects:", error);
       } else if (data) {
+        const sortedProjects = [...data].sort((a: any, b: any) =>
+          (a.name || "").localeCompare(b.name || ""),
+        );
         setProjects(
-          data.map((proj: any) => ({
+          sortedProjects.map((proj: any) => ({
             ...proj,
             start_date: proj.start_date || "",
           })) as Project[],
@@ -84,16 +87,22 @@ export function TableFilters({ filters, onFilterChange }: TableFiltersProps) {
               .filter((pos: any) => pos !== null && pos !== ""),
           ),
         ) as string[];
+        distinctPositions.sort((a, b) => a.localeCompare(b));
         setDisplayPositions(distinctPositions);
       }
     }
 
     async function fetchRoles() {
-      const { data, error } = await supabase.from("roles").select("id, name");
+      const { data, error } = await supabase
+        .from("roles")
+        .select("id, name");
       if (error) {
         console.error("Failed to fetch roles:", error);
       } else if (data) {
-        setRoles(data as Role[]);
+        const sortedRoles = [...data].sort((a: any, b: any) =>
+          (a.name || "").localeCompare(b.name || ""),
+        );
+        setRoles(sortedRoles as Role[]);
       }
     }
 


### PR DESCRIPTION
## Summary

Sorts dropdown options alphabetically (A–Z, case-insensitive) across mobile and desktop layouts, while keeping "All" default options pinned to the top in  .

## Changes

- **Project dropdown** — options sorted A–Z, case-insensitive
- **Position dropdown** — options sorted A–Z, case-insensitive
- **Role dropdown** — options sorted A–Z, case-insensitive
- **Internal Status dropdown** — left unchanged per task spec

## Notes

- "All Projects", "All Display Positions", "All Roles", and "All Internal Statuses" remain fixed at the top of their respective dropdowns, unaffected by sorting.
- Sorting applied consistently across mobile and desktop.

## BEFORE
<img width="1200" height="961" alt="2c167dbb-546e-4ca6-a2eb-f40ec59e3711" src="https://github.com/user-attachments/assets/5b9fcf94-e446-4718-b688-a5039badc77b" />

## AFTER
<img width="1917" height="928" alt="3e9d51f1-0acc-4efb-a530-b8031b4778e8" src="https://github.com/user-attachments/assets/2d1054eb-3b45-4afd-988a-c560013ea397" />
<img width="1907" height="938" alt="544628dc-8a55-4dec-a44e-2782fdd30d22" src="https://github.com/user-attachments/assets/f5a4568b-8b18-4743-89ee-8273be4c1bec" />
<img width="1576" height="930" alt="2d62f2a6-d7cd-42e4-a296-50766ad88106" src="https://github.com/user-attachments/assets/3a91d0c3-6899-4ada-b145-8896650c0504" />

## INACTIVE TAB AFTER
<img width="1537" height="943" alt="image" src="https://github.com/user-attachments/assets/aeb6859c-5773-466d-b255-8514d0d0cba1" />


## MOBILE VIEW
<img width="375" height="835" alt="3f718c8e-7bd0-44e3-82ca-249d400b9d2d" src="https://github.com/user-attachments/assets/9c0e67a8-5932-4504-913e-5f7a0e7edd22" />
