### PR TITLE
fix(codevs): show accepted developers on Be a Member (cherry-pick to prod)

### DIFF
--- a/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
+++ b/apps/codebility/app/(marketing)/codevs/_components/CodevsProfiles.tsx
@@ -15,7 +15,11 @@ export const revalidate = 0;
 
 export default async function CodevsProfiles() {
   const [{ data: allCodevs, error }] = await Promise.all([
-    getCodevs({ filters: { role_id: 10 } }), // show only Codevs with role_id 10 which is Codev
+    // Accepted developers are identified by application_status, not by role_id.
+    // The accept flow sets application_status "passed" while role_id tracks the
+    // Intern → Codev → Mentor progression, so filtering on role_id 10 hid every
+    // newly accepted developer. /profiles already uses this same filter.
+    getCodevs({ filters: { application_status: "passed" } }),
   ]);
 
   if (error) {


### PR DESCRIPTION
Cherry-pick of `7e4b0c33` from `dev` (originally PR #621) so the Be a Member fix reaches production without waiting on the rest of the release.

## Problem

`/codevs` (Be a Member) filters developers by `role_id = 10`, but the accept flow assigns `role_id = 4` (Intern). Accepted developers therefore never appear on the page, and only legacy role-10 devs show. `/profiles` filters on `application_status` and shows the correct people, which is the "parang iba ung devs rendered" mismatch Zeff reported.

## Change

One line — Be a Member now filters on `application_status: "passed"`, the same source of truth `/profiles` already uses.

## Why cherry-pick

`dev` is several commits ahead of `master` and also carries auth changes that aren't ready to ship. This isolates the user-visible fix.

## Test

- `/codevs` and `/profiles` should render the same set of developers
- Recently accepted developers should now appear on Be a Member

🤖 Generated with [Claude Code](https://claude.com/claude-code)
