### PR TITLE
fix(auth): remediate role 4 (Intern) admin privilege escalation and s…

### DIFF
--- a/apps/codebility/app/home/applicants/_service/action.ts
+++ b/apps/codebility/app/home/applicants/_service/action.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { NewApplicantType } from "./types";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireRole } from "@/lib/server/auth-guard";
 import { invalidateCache } from "@/lib/server/redis-cache";
 import { cacheKeys } from "@/lib/server/redis-cache-keys";
 
@@ -268,7 +269,7 @@ export async function multipleDenyApplicantAction(applicantIds: string[]) {
 
 export async function acceptApplicantAction(applicantId: string) {
     try {
-        const supabase = await createClientServerComponent();
+        const { supabase } = await requireRole("applicants");
 
         // update codev table
         const { error } = await supabase
@@ -298,7 +299,7 @@ export async function acceptApplicantAction(applicantId: string) {
 
 export async function multipleAcceptApplicantAction(applicantIds: string[]) {
     try {
-        const supabase = await createClientServerComponent();
+        const { supabase } = await requireRole("applicants");
 
         // update codev table
         const { error } = await supabase

--- a/apps/codebility/app/home/hire/_components/JobListingsTable.tsx
+++ b/apps/codebility/app/home/hire/_components/JobListingsTable.tsx
@@ -68,8 +68,8 @@ export default function JobListingsTable() {
   const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'closed' | 'draft'>('all');
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
 
-  // Check if user is admin (role_id 1 or 4)
-  const isAdmin = user?.role_id === 1 || user?.role_id === 4;
+  // Check if user is admin (role_id 1)
+  const isAdmin = user?.role_id === 1;
 
   // Filter jobs based on status
   const filteredJobs = jobs.filter(job => {

--- a/apps/codebility/app/home/hire/actions.ts
+++ b/apps/codebility/app/home/hire/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClientServerComponent } from "@/utils/supabase/server";
+import { requireRole } from "@/lib/server/auth-guard";
 import { createClient } from "@supabase/supabase-js";
 
 // Helper function to create service role client for admin operations
@@ -35,27 +35,8 @@ export async function updateJobListing(
   }
 ) {
   try {
-    const supabase = await createClientServerComponent();
-
-    // Get the current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: "Unauthorized - Please log in again" };
-    }
-
-    // Get user details to check role
-    const { data: userData, error: userError } = await supabase
-      .from('codev')
-      .select('id, role_id')
-      .eq('id', user.id)
-      .single();
-
-    if (userError || !userData) {
-      return { success: false, error: "User not found" };
-    }
-
-    // Check if user is admin (role_id 1 or 4)
-    const isAdmin = userData.role_id === 1 || userData.role_id === 4;
+    const { user, supabase, roleId } = await requireRole("clients");
+    const isAdmin = roleId === 1;
 
     // Get the job to check ownership
     const { data: job, error: jobError } = await supabase
@@ -69,7 +50,7 @@ export async function updateJobListing(
     }
 
     // Check permissions
-    if (!isAdmin && job.created_by !== userData.id) {
+    if (!isAdmin && job.created_by !== user.id) {
       return { success: false, error: "You don't have permission to edit this job" };
     }
 
@@ -116,28 +97,8 @@ export async function updateJobListing(
 
 export async function deleteJobListing(jobId: string) {
   try {
-    
-    const supabase = await createClientServerComponent();
-
-    // Get the current user
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return { success: false, error: "Unauthorized - Please log in again" };
-    }
-
-    // Get user details to check role
-    const { data: userData, error: userError } = await supabase
-      .from('codev')
-      .select('id, role_id')
-      .eq('id', user.id)
-      .single();
-
-    if (userError || !userData) {
-      return { success: false, error: "User not found" };
-    }
-
-    // Check if user is admin (role_id 1 or 4)
-    const isAdmin = userData.role_id === 1 || userData.role_id === 4;
+    const { user, supabase, roleId } = await requireRole("clients");
+    const isAdmin = roleId === 1;
 
     // Use service role client for admin operations to bypass RLS
     let queryClient;
@@ -177,7 +138,7 @@ export async function deleteJobListing(jobId: string) {
     const job = jobs[0];
 
     // Check permissions - only for non-admin users
-    if (!isAdmin && job.created_by !== userData.id) {
+    if (!isAdmin && job.created_by !== user.id) {
       return { success: false, error: "You don't have permission to delete this job" };
     }
 
@@ -211,27 +172,8 @@ export async function updateApplicationStatus(
   status: "pending" | "reviewing" | "shortlisted" | "rejected" | "hired"
 ) {
   try {
-    const supabase = await createClientServerComponent();
-
-    // Get the current user
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
-    }
-
-    // Get user details to check role
-    const { data: userData } = await supabase
-      .from('codev')
-      .select('id, role_id')
-      .eq('id', user.id)
-      .single();
-
-    if (!userData) {
-      return { success: false, error: "User not found" };
-    }
-
-    // Check if user is admin (role_id 1 or 4)
-    const isAdmin = userData.role_id === 1 || userData.role_id === 4;
+    const { user, supabase, roleId } = await requireRole("clients");
+    const isAdmin = roleId === 1;
 
     // Get the application to check job ownership
     const { data: application } = await supabase
@@ -256,7 +198,7 @@ export async function updateApplicationStatus(
     }
 
     // Check permissions
-    if (!isAdmin && job.created_by !== userData.id) {
+    if (!isAdmin && job.created_by !== user.id) {
       return { success: false, error: "You don't have permission to update this application" };
     }
 
@@ -280,33 +222,17 @@ export async function updateApplicationStatus(
 
     return { success: true, data: updatedApplication };
   } catch (error) {
-    return { success: false, error: "An unexpected error occurred" };
+    return { 
+      success: false, 
+      error: error instanceof Error ? error.message : "An unexpected error occurred" 
+    };
   }
 }
 
 export async function deleteJobApplication(applicationId: string, jobId: string) {
   try {
-    const supabase = await createClientServerComponent();
-
-    // Get the current user
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
-    }
-
-    // Get user details to check role
-    const { data: userData } = await supabase
-      .from('codev')
-      .select('id, role_id')
-      .eq('id', user.id)
-      .single();
-
-    if (!userData) {
-      return { success: false, error: "User not found" };
-    }
-
-    // Check if user is admin (role_id 1 or 4)
-    const isAdmin = userData.role_id === 1 || userData.role_id === 4;
+    const { user, supabase, roleId } = await requireRole("clients");
+    const isAdmin = roleId === 1;
 
     // Get the job to check ownership
     const { data: job } = await supabase
@@ -320,7 +246,7 @@ export async function deleteJobApplication(applicationId: string, jobId: string)
     }
 
     // Check permissions
-    if (!isAdmin && job.created_by !== userData.id) {
+    if (!isAdmin && job.created_by !== user.id) {
       return { success: false, error: "You don't have permission to delete this application" };
     }
 
@@ -339,7 +265,10 @@ export async function deleteJobApplication(applicationId: string, jobId: string)
 
     return { success: true };
   } catch (error) {
-    return { success: false, error: "An unexpected error occurred" };
+    return { 
+      success: false, 
+      error: error instanceof Error ? error.message : "An unexpected error occurred" 
+    };
   }
 }
 
@@ -348,27 +277,8 @@ export async function updateJobListingStatus(
   status: "active" | "closed" | "draft"
 ) {
   try {
-    const supabase = await createClientServerComponent();
-
-    // Get the current user
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return { success: false, error: "Unauthorized" };
-    }
-
-    // Get user details to check role
-    const { data: userData } = await supabase
-      .from('codev')
-      .select('id, role_id')
-      .eq('id', user.id)
-      .single();
-
-    if (!userData) {
-      return { success: false, error: "User not found" };
-    }
-
-    // Check if user is admin (role_id 1 or 4)
-    const isAdmin = userData.role_id === 1 || userData.role_id === 4;
+    const { user, supabase, roleId } = await requireRole("clients");
+    const isAdmin = roleId === 1;
 
     // Get the job to check ownership
     const { data: job } = await supabase
@@ -382,7 +292,7 @@ export async function updateJobListingStatus(
     }
 
     // Check permissions
-    if (!isAdmin && job.created_by !== userData.id) {
+    if (!isAdmin && job.created_by !== user.id) {
       return { success: false, error: "You don't have permission to update this job" };
     }
 
@@ -406,6 +316,9 @@ export async function updateJobListingStatus(
 
     return { success: true, data: updatedJob };
   } catch (error) {
-    return { success: false, error: "An unexpected error occurred" };
+    return { 
+      success: false, 
+      error: error instanceof Error ? error.message : "An unexpected error occurred" 
+    };
   }
 }

--- a/apps/codebility/supabase/migrations/20260219_rls_hotfix.sql
+++ b/apps/codebility/supabase/migrations/20260219_rls_hotfix.sql
@@ -13,7 +13,7 @@
 
 CREATE OR REPLACE VIEW public.admin_users AS
 SELECT id FROM public.codev
-WHERE role_id IN (1, 4);  -- Admin and Super Admin role IDs
+WHERE role_id IN (1, 4);  -- Historical: Admin (1). Note: role 4 is Intern, not Super Admin; see migration 20260816_fix_admin_users_view_role4.sql
 
 
 -- =============================================================================

--- a/apps/codebility/supabase/migrations/20260816_fix_admin_users_view_role4.sql
+++ b/apps/codebility/supabase/migrations/20260816_fix_admin_users_view_role4.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- Migration: Fix admin_users View Privilege Escalation (Role 4 is Intern)
+-- Date: 2026-08-16
+--
+-- Description:
+-- Updates public.admin_users view definition so that it strictly returns users
+-- with role_id = 1 (Admin) and application_status = 'passed'.
+-- Matches exact column schema signature of the live view.
+-- =============================================================================
+
+CREATE OR REPLACE VIEW public.admin_users AS
+SELECT 
+    codev.id,
+    codev.email_address,
+    codev.first_name,
+    codev.last_name,
+    codev.role_id
+FROM public.codev
+WHERE codev.role_id = 1 
+  AND codev.application_status = 'passed';

--- a/apps/codebility/supabase/migrations/RLS_POLICY_TEMPLATES.md
+++ b/apps/codebility/supabase/migrations/RLS_POLICY_TEMPLATES.md
@@ -365,7 +365,7 @@ Instead of hard-coding `role_id = 1`, use a view:
 ```sql
 CREATE OR REPLACE VIEW admin_users AS
 SELECT id FROM codev
-WHERE role_id IN (1, 4);  -- Admin and Super Admin
+WHERE role_id = 1;  -- Admin
 ```
 
 Then policies become:


### PR DESCRIPTION
## Summary
Fixes a critical privilege escalation defect where Interns (`role_id: 4`) were mistakenly granted administrator capabilities across Hire page server actions, client-side table rendering, and Supabase Row-Level Security (RLS) policies via the `admin_users` view.

Guards the applicant acceptance flow (`acceptApplicantAction` and `multipleAcceptApplicantAction`) with `requireRole("applicants")` to block unauthorized users from self-accepting into the Intern role to inherit escalated rights.

Preserves the legitimate role lifecycle: accepted applicants continue to be assigned `role_id: 4` (Intern) with status `"passed"`.

---

## Changes

### 1. Hire Module Server Actions & Client UI
- **`apps/codebility/app/home/hire/actions.ts`**:
  - Replaced hardcoded `userData.role_id === 1 || userData.role_id === 4` checks in `updateJobListing`, `deleteJobListing`, `updateApplicationStatus`, `deleteJobApplication`, and `updateJobListingStatus` with `requireRole("clients")` from `@/lib/server/auth-guard`.
  - Enforced strict admin evaluation as `roleId === 1`. Non-admin users must own the resource (`created_by === user.id`).
- **`apps/codebility/app/home/hire/_components/JobListingsTable.tsx`**:
  - Updated client-side check to `const isAdmin = user?.role_id === 1;` (removed `|| user?.role_id === 4`).

### 2. Applicant Acceptance Server Actions
- **`apps/codebility/app/home/applicants/_service/action.ts`**:
  - Guarded `acceptApplicantAction` and `multipleAcceptApplicantAction` with `requireRole("applicants")`.
  - Blocks unauthenticated callers and self-accepting applicants while preserving `application_status: "passed"` and `role_id: 4`.

### 3. Database RLS & Documentation
- **`apps/codebility/supabase/migrations/20260816_fix_admin_users_view_role4.sql`**:
  - Created migration updating `public.admin_users` view to match the exact schema signature and filter strictly by `role_id = 1 AND application_status = 'passed'`.
- **`apps/codebility/supabase/migrations/20260219_rls_hotfix.sql`**:
  - Corrected misleading historical comment labeling role 4 as "Super Admin".
- **`apps/codebility/supabase/migrations/RLS_POLICY_TEMPLATES.md`**:
  - Updated template documentation to prevent future propagation of the role 4 mislabel.

---

## Live Database & RLS Analysis

- **Live Variant in Production**: `admin_users` view consumed by all RLS policies across the database.
- **Before Definition**:
  ```sql
  SELECT codev.id, codev.email_address, codev.first_name, codev.last_name, codev.role_id
  FROM codev
  WHERE (codev.role_id = ANY (ARRAY[1, 4])) AND codev.application_status = 'passed'::text;
